### PR TITLE
Fixing squid: S1118 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/MsgConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/MsgConst.java
@@ -3,9 +3,11 @@ package com.dounine.clouddisk360.parser.deserializer;
 import com.dounine.clouddisk360.exception.CloudDiskException;
 
 public final class MsgConst {
-
+   
 	public static final CloudDiskException CONFIG_COOKIESTORE_MSG = new CloudDiskException("请配置非空config对象");
 	public static final CloudDiskException BASE_PATH_MSG = new CloudDiskException("请初始化BasePathCommon中的basePath目录所在位置");
 	
 	public static final String HOST_VALUE_NOT_NULL = "DifferPress中的RedirectUrl为空";
+	
+	private MsgConst(){}
 }

--- a/src/main/java/com/dounine/clouddisk360/pool/PoolingHttpClientConnection.java
+++ b/src/main/java/com/dounine/clouddisk360/pool/PoolingHttpClientConnection.java
@@ -25,7 +25,7 @@ import java.security.cert.X509Certificate;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-public class PoolingHttpClientConnection {
+public final class PoolingHttpClientConnection {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(PoolingHttpClientConnection.class);
 
@@ -34,7 +34,9 @@ public class PoolingHttpClientConnection {
 	static{
 		initHttpClientConnectionManager();
 	}
-
+	
+	private PoolingHttpClientConnection(){}
+	
 	public static void initHttpClientConnectionManager() {
 		if(null!=CM){
 			return;

--- a/src/main/java/com/dounine/clouddisk360/store/BasePathCommon.java
+++ b/src/main/java/com/dounine/clouddisk360/store/BasePathCommon.java
@@ -6,5 +6,6 @@ public final class BasePathCommon {
 	 * 360云盘模块根模块
 	 */
 	public static String BASE_PATH;
-
+	
+    private BasePathCommon(){}
 }

--- a/src/main/java/com/dounine/clouddisk360/util/MD5Util.java
+++ b/src/main/java/com/dounine/clouddisk360/util/MD5Util.java
@@ -4,8 +4,10 @@ import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-public class MD5Util {
+public final class MD5Util {
 
+	private MD5Util(){}
+	
     public final static String MD5(final String s) {
         byte[] btInput = null;
         try {

--- a/src/main/java/com/dounine/clouddisk360/util/TimeUtil.java
+++ b/src/main/java/com/dounine/clouddisk360/util/TimeUtil.java
@@ -1,7 +1,9 @@
 package com.dounine.clouddisk360.util;
 
-public class TimeUtil {
-
+public final class TimeUtil {
+	
+    private TimeUtil(){}
+    
 	public static String getTimeLenth(final int length){
 		final String time = String.valueOf(System.currentTimeMillis());
 		if(length>time.length()){

--- a/src/main/java/com/dounine/clouddisk360/util/URLUtil.java
+++ b/src/main/java/com/dounine/clouddisk360/util/URLUtil.java
@@ -3,8 +3,10 @@ package com.dounine.clouddisk360.util;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 
-public class URLUtil {
+public final class URLUtil {
 
+	private URLUtil(){}
+	
 	public final static String decode(final String code){
 		try {
 			return URLDecoder.decode(code,"utf-8");


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118
 Please let me know if you have any questions.
Fevzi Ozgul
