### PR TITLE
Fixing squid: S00100  Method names should comply with a naming convention

### DIFF
--- a/src/main/java/com/dounine/clouddisk360/captthread/CaptThread.java
+++ b/src/main/java/com/dounine/clouddisk360/captthread/CaptThread.java
@@ -71,7 +71,7 @@ public class CaptThread implements Runnable{
 					returnExist = false;
 					CaptchaThreadValidator.removeCaptchaValidator(account);
 				}
-				final PassportParser _passportParser = get_passport(account);//获取手动变动的验证码解析器
+				final PassportParser _passportParser = getPassport(account);//获取手动变动的验证码解析器
 				if(null!=_passportParser){
 					passportParser = _passportParser;
 				}
@@ -82,7 +82,7 @@ public class CaptThread implements Runnable{
 
 		if (null == cValidator) {
 			CaptchaThreadValidator.removeCaptchaValidator(account);
-			remove_passport(account);//移除验证码解析器
+			removePassport(account);//移除验证码解析器
 			LOGGER.info("验证码超时未处理,线程监听验证结束");
 		}else{
 			final LoginParameter loginParameter = new LoginParameter();
@@ -98,7 +98,7 @@ public class CaptThread implements Runnable{
 			CaptchaThreadValidator.emptyCaptchaValue(account);//清空验证码
 			if (null != login&& StringUtils.isNotBlank(login.getQid())) {
 				CaptchaThreadValidator.updateValidMsgAndTime(account,"登录成功",true);//更新验证时间
-				remove_passport(account);//移除验证码解析器
+				removePassport(account);//移除验证码解析器
 				LOGGER.info("线程登录成功");
 			}else if(null==login||login.getErrno()!=0){
 				CaptchaThreadValidator.updateValidMsgAndTime(account,login.getErrmsg(),false);//更新验证时间
@@ -110,19 +110,19 @@ public class CaptThread implements Runnable{
 		}
 	}
 
-	public static void push_passport(final String account,final PassportParser passportParser){
+	public static void pushPassport(final String account,final PassportParser passportParser){
 		synchronized (PASSPORT_PARSER_MAP){
 			PASSPORT_PARSER_MAP.put(account,passportParser);
 		}
 	}
 
-	public PassportParser remove_passport(final String account){
+	public PassportParser removePassport(final String account){
 		synchronized (PASSPORT_PARSER_MAP){
 			return PASSPORT_PARSER_MAP.remove(account);
 		}
 	}
 
-	public PassportParser get_passport(final String account){
+	public PassportParser getPassport(final String account){
 		synchronized (PASSPORT_PARSER_MAP){
 			return PASSPORT_PARSER_MAP.get(account);
 		}

--- a/src/main/java/com/dounine/clouddisk360/parser/PassportParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/PassportParser.java
@@ -37,7 +37,7 @@ public class PassportParser extends
 				parameter.setUri(captcha.getCaptchaUrl());
 				if(captcha.getCaptchaFlag()){//需要验码
 					final Passport passport = super.parse(parameter);
-					CaptThread.push_passport(loginUserToken.getAccount(),this);//手动更新验证码
+					CaptThread.pushPassport(loginUserToken.getAccount(),this);//手动更新验证码
 					return passport;
 				}
 			}

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/download/dladdress/FileDownloadAddressData.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/download/dladdress/FileDownloadAddressData.java
@@ -6,11 +6,11 @@ public class FileDownloadAddressData {
 
 	private String download_url;
 
-	public String getDownload_url() {
+	public String getDownloadUrl() {
 		return download_url;
 	}
 
-	public void setDownload_url(String download_url) {
+	public void setDownloadUrl(String download_url) {
 		this.download_url = download_url;
 	}
 

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/history/data/FileHistoryData.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/history/data/FileHistoryData.java
@@ -17,11 +17,11 @@ public class FileHistoryData {
 		this.current = current;
 	}
 
-	public List<FileHistoryList> getFhistory_list() {
+	public List<FileHistoryList> getFhistoryList() {
 		return fhistory_list;
 	}
 
-	public void setFhistory_list(List<FileHistoryList> fhistory_list) {
+	public void setFhistoryList(List<FileHistoryList> fhistory_list) {
 		this.fhistory_list = fhistory_list;
 	}
 

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/move/list/FileListAjaxData.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/move/list/FileListAjaxData.java
@@ -6,11 +6,11 @@ public class FileListAjaxData {
 	private String nid;
 	private String file_name;
 
-	public String getFile_path() {
+	public String getFilePath() {
 		return file_path;
 	}
 
-	public void setFile_path(String file_path) {
+	public void setFilePath(String file_path) {
 		this.file_path = file_path;
 	}
 
@@ -22,11 +22,11 @@ public class FileListAjaxData {
 		this.nid = nid;
 	}
 
-	public String getFile_name() {
+	public String getFileName() {
 		return file_name;
 	}
 
-	public void setFile_name(String file_name) {
+	public void setFileName(String file_name) {
 		this.file_name = file_name;
 	}
 

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/recycle/FileRecycleData.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/recycle/FileRecycleData.java
@@ -6,11 +6,11 @@ public class FileRecycleData {
 
 	private String task_id;
 
-	public String getTask_id() {
+	public String getTaskId() {
 		return task_id;
 	}
 
-	public void setTask_id(String task_id) {
+	public void setTaskId(String task_id) {
 		this.task_id = task_id;
 	}
 

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/search/FileSearchData.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/search/FileSearchData.java
@@ -11,11 +11,11 @@ public class FileSearchData {
 	private Long retnum;
 	private Long total;
 
-	public List<FileSearchList> getNode_list() {
+	public List<FileSearchList> getNodeList() {
 		return node_list;
 	}
 
-	public void setNode_list(List<FileSearchList> node_list) {
+	public void setNodeList(List<FileSearchList> node_list) {
 		this.node_list = node_list;
 	}
 

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/search/FileSearchList.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/search/FileSearchList.java
@@ -23,27 +23,27 @@ public class FileSearchList {
 	private String count_size;
 	private String file_name;
 
-	public String getFile_path() {
+	public String getFilePath() {
 		return file_path;
 	}
 
-	public void setFile_path(String file_path) {
+	public void setFilePath(String file_path) {
 		this.file_path = file_path;
 	}
 
-	public String getFile_size() {
+	public String getFileSize() {
 		return file_size;
 	}
 
-	public void setFile_size(String file_size) {
+	public void setFileSize(String file_size) {
 		this.file_size = file_size;
 	}
 
-	public Boolean getIs_dir() {
+	public Boolean getIsDir() {
 		return is_dir;
 	}
 
-	public void setIs_dir(Boolean is_dir) {
+	public void setIsDir(Boolean is_dir) {
 		this.is_dir = is_dir;
 	}
 
@@ -55,19 +55,19 @@ public class FileSearchList {
 		this.fhash = fhash;
 	}
 
-	public String getCreate_time() {
+	public String getCreateTime() {
 		return create_time;
 	}
 
-	public void setCreate_time(String create_time) {
+	public void setCreateTime(String create_time) {
 		this.create_time = create_time;
 	}
 
-	public String getModify_time() {
+	public String getModifyTime() {
 		return modify_time;
 	}
 
-	public void setModify_time(String modify_time) {
+	public void setModifyTime(String modify_time) {
 		this.modify_time = modify_time;
 	}
 
@@ -79,11 +79,11 @@ public class FileSearchList {
 		this.nid = nid;
 	}
 
-	public String getServer_time() {
+	public String getServerTime() {
 		return server_time;
 	}
 
-	public void setServer_time(String server_time) {
+	public void setServerTime(String server_time) {
 		this.server_time = server_time;
 	}
 
@@ -103,27 +103,27 @@ public class FileSearchList {
 		this.favorite = favorite;
 	}
 
-	public String getFile_location() {
+	public String getFileLocation() {
 		return file_location;
 	}
 
-	public void setFile_location(String file_location) {
+	public void setFileLocation(String file_location) {
 		this.file_location = file_location;
 	}
 
-	public Boolean getIs_link() {
+	public Boolean getIsLink() {
 		return is_link;
 	}
 
-	public void setIs_link(Boolean is_link) {
+	public void setIsLink(Boolean is_link) {
 		this.is_link = is_link;
 	}
 
-	public String getLink_url() {
+	public String getLinkUrl() {
 		return link_url;
 	}
 
-	public void setLink_url(String link_url) {
+	public void setLinkUrl(String link_url) {
 		this.link_url = link_url;
 	}
 
@@ -171,15 +171,15 @@ public class FileSearchList {
 		return count_size;
 	}
 
-	public void setCount_size(String count_size) {
+	public void setCountSize(String count_size) {
 		this.count_size = count_size;
 	}
 
-	public String getFile_name() {
+	public String getFileName() {
 		return file_name;
 	}
 
-	public void setFile_name(String file_name) {
+	public void setFileName(String file_name) {
 		this.file_name = file_name;
 	}
 

--- a/src/test/java/com/dounine/clouddisk360/parse/FileDownloadFileParserTest.java
+++ b/src/test/java/com/dounine/clouddisk360/parse/FileDownloadFileParserTest.java
@@ -38,7 +38,7 @@ public class FileDownloadFileParserTest extends TestCase {
 		final FileDownloadFileParser fileDownloadFileParser = new FileDownloadFileParser();
 		fileDownloadFileParser.dataSmooth(fileDownloadAddressParser);
 		final FileDownloadFileParameter fileDownloadFileParameter = new FileDownloadFileParameter();
-		fileDownloadFileParameter.setDownloadPath(fileDownloadAddress.getData().getDownload_url());
+		fileDownloadFileParameter.setDownloadPath(fileDownloadAddress.getData().getDownloadUrl());
 		fileDownloadFileParameter.setFileName(fileDownloadAddressParameter.getFname());
 		final FileDownloadFile fileDownloadFile = fileDownloadFileParser.parse(fileDownloadFileParameter);
 


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S00100 - “Method names should comply with a naming convention ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S00100
 Please let me know if you have any questions.
Fevzi Ozgul
