### PR TITLE
Fixing squid: S1170 Public constants and fields initialized at declaration should be "static final" rather than merely "final"

### DIFF
--- a/src/main/java/com/dounine/clouddisk360/captthread/CaptThread.java
+++ b/src/main/java/com/dounine/clouddisk360/captthread/CaptThread.java
@@ -22,7 +22,7 @@ public class CaptThread implements Runnable{
 	private static final Logger LOGGER = LoggerFactory.getLogger(CaptThread.class);
 
 	private static Map<String,PassportParser> PASSPORT_PARSER_MAP = new ConcurrentHashMap();
-	private final int timeOutSeconds = CaptchaThreadValidator.timeoutMin;
+	private static final int timeOutSeconds = CaptchaThreadValidator.timeoutMin;
 	private static final int seconds = 3,sleepTimeSeconds = 1000*seconds;
 
 	private final DifferPressParser differPressParser;

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/BaseConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/BaseConst.java
@@ -4,21 +4,21 @@ import com.dounine.clouddisk360.parser.deserializer.user.IBaseConst;
 
 public class BaseConst implements IBaseConst{
 
-	public final String QID_NAME = "qid";
-	public final String SRC_KEY = "src";
-	public final String SRC_VAL = "pcw_cloud";
+	public static final String QID_NAME = "qid";
+	public static final String SRC_KEY = "src";
+	public static final String SRC_VAL = "pcw_cloud";
 
-	public final String FROM_KEY = "from";
-	public final String FROM_VAL = "pcw_cloud";
+	public static final String FROM_KEY = "from";
+	public static final String FROM_VAL = "pcw_cloud";
 
-	public final String CHARSET_KEY = "charset";
-	public final String CHARSET_VAL = "UTF-8";
+	public static final String CHARSET_KEY = "charset";
+	public static final String CHARSET_VAL = "UTF-8";
 
-	public final String REQUESTSCEMA_KEY = "requestScema";
-	public final String REQUESTSCEMA_VAL = "http";
+	public static final String REQUESTSCEMA_KEY = "requestScema";
+	public static final String REQUESTSCEMA_VAL = "http";
 
-	public final String O_KEY = "o";
-	public final String O_VAL = "sso";
+	public static final String O_KEY = "o";
+	public static final String O_VAL = "sso";
 
 	public static final String CONNECTION_KEY = "Connection";
 	public static final String CONNECTION_VAL = "keep-alive";
@@ -30,8 +30,8 @@ public class BaseConst implements IBaseConst{
 	public static final String REFERER_VAL = "http://yunpan.360.cn/";
 
 	public static final String ORIGIN_KEY = "Origin";
-	public final String AJAX_KEY = "ajax";
-	public final String AJAX_VAL = "1";
+	public static final String AJAX_KEY = "ajax";
+	public static final String AJAX_VAL = "1";
 
 	public static final String USER_AGENT_KEY = "User-Agent";
 	public static final String USER_AGENT_VAL = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.80 Safari/537.36";
@@ -55,8 +55,8 @@ public class BaseConst implements IBaseConst{
 	public static final String HOST_VAL = "login.360.cn";
 
 	public static final String COOKIES_PATH_NAME = "cookies.txt";
-	public final String PAGE_NAME = "page";
-	public final String PAGE_SIZE_NAME = "page_size";
+	public static final String PAGE_NAME = "page";
+	public static final String PAGE_SIZE_NAME = "page_size";
 
 	public static final String COOKIE_NAME = "cookie";
 	public static final String[] BASE_COOKIES_VALUES = { "Q", "T" };

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/captcha/CaptchaConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/captcha/CaptchaConst.java
@@ -4,14 +4,14 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class CaptchaConst extends BaseConst {
 
-	public final String URI_PATH = "http://login.360.cn/";
+	public static final String URI_PATH = "http://login.360.cn/";
 	
-	public final String M_KEY = "m";
-	public final String M_VAL = "checkNeedCaptcha";
+	public static final String M_KEY = "m";
+	public static final String M_VAL = "checkNeedCaptcha";
 
-	public final String CAPTCHAAPP_KEY = "captchaApp";
-	public final String CAPTCHAAPP_VAL = "i360";
+	public static final String CAPTCHAAPP_KEY = "captchaApp";
+	public static final String CAPTCHAAPP_VAL = "i360";
 
-	public final String ACCOUNT_NAME = "account";
+	public static final String ACCOUNT_NAME = "account";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/differpre/DifferPressConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/differpre/DifferPressConst.java
@@ -4,14 +4,14 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class DifferPressConst extends BaseConst {
 
-	public final String URI_PATH = "http://yunpan.360.cn/user/login";
+	public static final String URI_PATH = "http://yunpan.360.cn/user/login";
 
-	public final String ST_KEY = "st";
+	public static final String ST_KEY = "st";
 	public static final String ST_VAL = "1457085516";
 
-	public final String SID_KEY = "sid";
+	public static final String SID_KEY = "sid";
 
-	public final String KEEPALIVE_KEY = "keepalive";
+	public static final String KEEPALIVE_KEY = "keepalive";
 	public final String KEEPALIVE_VAL = "1";
 
 	public static final String HOST_VAL = "yunpan.360.cn";

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/create/FileCreateConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/create/FileCreateConst.java
@@ -4,7 +4,7 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileCreateConst extends BaseConst {
 
-	public final String URI_PATH = "/file/mkdir";
+	public static final String URI_PATH = "/file/mkdir";
 
 	@Override
 	public String getUriPath() {
@@ -19,6 +19,6 @@ public final class FileCreateConst extends BaseConst {
 
 	public static final String USERNAME_NAME = "userName";
 
-	public final String PATH_NAME = "path";
+	public static final String PATH_NAME = "path";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/download/dladdress/FileDownloadAddressConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/download/dladdress/FileDownloadAddressConst.java
@@ -11,7 +11,7 @@ public final class FileDownloadAddressConst extends BaseConst {
 		return URI_PATH;
 	}
 
-	public final String NID_NAME = "nid";
-	public final String FNAME_NAME = "fname";
+	public static final String NID_NAME = "nid";
+	public static final String FNAME_NAME = "fname";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/download/upaddress/FileUploadAddressConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/download/upaddress/FileUploadAddressConst.java
@@ -4,7 +4,7 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileUploadAddressConst extends BaseConst {
 
-	public final String URI_PATH = "/upload/getuploadaddress/";
+	public static final String URI_PATH = "/upload/getuploadaddress/";
 
 	@Override
 	public String getUriPath() {

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/exist/FileExistConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/exist/FileExistConst.java
@@ -4,14 +4,14 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileExistConst extends BaseConst {
 
-	public final String URI_PATH = "/file/detectFileExists";
+	public static final String URI_PATH = "/file/detectFileExists";
 
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String DIR_NAME = "dir";
-	public final String FNAME_NAME = "fname[]";
+	public static final String DIR_NAME = "dir";
+	public static final String FNAME_NAME = "fname[]";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/history/FileHistoryConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/history/FileHistoryConst.java
@@ -4,17 +4,17 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileHistoryConst extends BaseConst {
 
-	public final String URI_PATH = "/fHistory/getFileHistory/";
+	public static final String URI_PATH = "/fHistory/getFileHistory/";
 
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String NID_NAME = "nid";
-	public final String HIS_NID_NAME = "his_nid";
-	public final String START_NAME = "start";
-	public final String NUM_NAME = "num";
-	public final String SOURCE_NAME = "source";
+	public static final String NID_NAME = "nid";
+	public static final String HIS_NID_NAME = "his_nid";
+	public static final String START_NAME = "start";
+	public static final String NUM_NAME = "num";
+	public static final String SOURCE_NAME = "source";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/history/restore/FileRestoreConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/history/restore/FileRestoreConst.java
@@ -4,15 +4,15 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileRestoreConst extends BaseConst {
 	
-	public final String URI_PATH = "/fHistory/restore";
+	public static final String URI_PATH = "/fHistory/restore";
 
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String NID_NAME = "nid";
-	public final String ID_NAME = "id";
-	public final String SOURCE_NAME = "source";
+	public static final String NID_NAME = "nid";
+	public static final String ID_NAME = "id";
+	public static final String SOURCE_NAME = "source";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/info/FileInfoConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/info/FileInfoConst.java
@@ -4,8 +4,8 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileInfoConst extends BaseConst {
 
-	public final String PATH_NAME = "path";
-	public final String NEWPATH_NAME = "newpath";
-	public final String NID_NAME = "nid";
+	public static final String PATH_NAME = "path";
+	public static final String NEWPATH_NAME = "newpath";
+	public static final String NID_NAME = "nid";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/list/FileListConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/list/FileListConst.java
@@ -4,7 +4,7 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileListConst extends BaseConst {
 
-	public final String URI_PATH = "/file/list";
+	public static final String URI_PATH = "/file/list";
 
 	@Override
 	public String getUriPath() {
@@ -18,12 +18,12 @@ public final class FileListConst extends BaseConst {
 	public static final String M_VAL = "getToken";
 
 	public static final String USERNAME_NAME = "userName";
-	public final String TYPE_NAME = "type";
-	public final String PATH_NAME = "path";
-	public final String ORDER_NAME = "order";
-	public final String FIELD_KEY = "field";
+	public static final String TYPE_NAME = "type";
+	public static final String PATH_NAME = "path";
+	public static final String ORDER_NAME = "order";
+	public static final String FIELD_KEY = "field";
 	public static final String FIELD_VAL = "file_name";
 	public static final String PAGE_NAME = "page";
-	public final String PAGE_SIZE_NAME = "page_size";
+	public static final String PAGE_SIZE_NAME = "page_size";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/move/FileMoveConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/move/FileMoveConst.java
@@ -4,15 +4,15 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileMoveConst extends BaseConst {
 
-	public final String URI_PATH = "/file/move/";
+	public static  final String URI_PATH = "/file/move/";
 
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String PATH_NAME = "path[]";
-	public final String NEWPATH_NAME = "newpath";
+	public static final String PATH_NAME = "path[]";
+	public static final String NEWPATH_NAME = "newpath";
 	public static final String NID_NAME = "nid";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/move/list/FileListAjaxConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/move/list/FileListAjaxConst.java
@@ -4,15 +4,15 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileListAjaxConst extends BaseConst {
 	
-	public final String URI_PATH = "/file/listAjax";
+	public static final String URI_PATH = "/file/listAjax";
 
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String PATH_NAME = "path";
-	public final String ID_NAME = "id";
-	public final String NID_NAME = "nid";
+	public static final String PATH_NAME = "path";
+	public static final String ID_NAME = "id";
+	public static final String NID_NAME = "nid";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/recycle/FileRecycleConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/recycle/FileRecycleConst.java
@@ -4,13 +4,13 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileRecycleConst extends BaseConst {
 
-	public final String URI_PATH = "/file/asyncRecycle/";
+	public static final String URI_PATH = "/file/asyncRecycle/";
 
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String PATH_NAME = "path[]";
+	public static final String PATH_NAME = "path[]";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/rename/FileRenameConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/rename/FileRenameConst.java
@@ -4,15 +4,15 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileRenameConst extends BaseConst {
 
-	public final String URI_PATH = "/file/rename";
+	public static final String URI_PATH = "/file/rename";
 
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String PATH_NAME = "path";
-	public final String NEWPATH_NAME = "newpath";
-	public final String NID_NAME = "nid";
+	public static final String PATH_NAME = "path";
+	public static final String NEWPATH_NAME = "newpath";
+	public static final String NID_NAME = "nid";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/search/FileSearchConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/search/FileSearchConst.java
@@ -4,15 +4,15 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileSearchConst extends BaseConst {
 
-	public final String URI_PATH = "/file/searchList";
+	public static final String URI_PATH = "/file/searchList";
 
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String KEY_NAME = "key";
-	public final String ISFPATH_NAME = "is_fpath";
+	public static final String KEY_NAME = "key";
+	public static final String ISFPATH_NAME = "is_fpath";
 
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/trends/FileTrendsListConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/trends/FileTrendsListConst.java
@@ -4,7 +4,7 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileTrendsListConst extends BaseConst {
 
-	public final String URI_PATH = "/trends/getTrendsList";
+	public static final String URI_PATH = "/trends/getTrendsList";
 
 	@Override
 	public String getUriPath() {

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/upload/FileUploadConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/upload/FileUploadConst.java
@@ -4,7 +4,7 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileUploadConst extends BaseConst {
 
-	public final String URI_PATH = "/webupload?devtype=web";
+	public static final String URI_PATH = "/webupload?devtype=web";
 	
 	public static final String PATH_NAME = "path";
 	public static final String NEWPATH_NAME = "newpath";

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/upload/addfile/FileAddFileConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/upload/addfile/FileAddFileConst.java
@@ -4,14 +4,14 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileAddFileConst extends BaseConst {
 
-	public final String URI_PATH = "/upload/addfile";
+	public static final String URI_PATH = "/upload/addfile";
 
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String TK_NAME = "tk";
+	public static final String TK_NAME = "tk";
 	public static final String NID_NAME = "nid";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/login/LoginConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/login/LoginConst.java
@@ -5,51 +5,51 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public class LoginConst extends BaseConst {
 
 	public static final String USER_INFO_PATH_NAME = "user/userInfo.txt";
-	public final String URI_PATH = "https://login.360.cn/";
+	public static final String URI_PATH = "https://login.360.cn/";
 
 	public static final String LOGIN_URL = "https://login.360.cn/";
 	
 	public static final String QUCRYPTCODE_NAME = "quCryptCode";
 
-	public final String REQUESTSCEMA_KEY = "requestScema";
-	public final String REQUESTSCEMA_VAL = "https";
+	public static final String REQUESTSCEMA_KEY = "requestScema";
+	public static final String REQUESTSCEMA_VAL = "https";
 
-	public final String LM_KEY = "lm";
-	public final String LM_VAL = "0";
+	public static final String LM_KEY = "lm";
+	public static final String LM_VAL = "0";
 
-	public final String CAPTFLAG_KEY = "captFlag";
-	public final String CAPTFLAG_VAL = "1";
+	public static final String CAPTFLAG_KEY = "captFlag";
+	public static final String CAPTFLAG_VAL = "1";
 
-	public final String RTYPE_KEY = "rtype";
-	public final String RTYPE_VAL = "data";
+	public static final String RTYPE_KEY = "rtype";
+	public static final String RTYPE_VAL = "data";
 
-	public final String VALIDATELM_KEY = "validatelm";
-	public final String VALIDATELM_VAL = "0";
+	public static final String VALIDATELM_KEY = "validatelm";
+	public static final String VALIDATELM_VAL = "0";
 
 	/**
 	 * 记住我登录
 	 */
-	public final String ISKEEPALIVE_KEY = "isKeepAlive";
-	public final String ISKEEPALIVE_VAL = "1";
+	public static final String ISKEEPALIVE_KEY = "isKeepAlive";
+	public static final String ISKEEPALIVE_VAL = "1";
 
-	public final String CAPTCHAAPP_KEY = "captchaApp";
-	public final String CAPTCHAAPP_VAL = "i360";
+	public static final String CAPTCHAAPP_KEY = "captchaApp";
+	public static final String CAPTCHAAPP_VAL = "i360";
 
-	public final String TYPE_KEY = "type";
+	public static final String TYPE_KEY = "type";
 	public static final String TYPE_VAL = "normal";
 
-	public final String CAPTCHA_KEY = "captcha";
+	public static final String CAPTCHA_KEY = "captcha";
 
 	public static final String PROXY_KEY = "proxy";
 	public static final String PROXY_VAL = "http://yunpan.360.cn/psp_jump.html";
 
-	public final String M_KEY = "m";
-	public final String M_VAL = "login";
+	public static final String M_KEY = "m";
+	public static final String M_VAL = "login";
 
-	public final String TOKEN_NAME = "token";
-	public final String PASSWORD_NAME = "password";
-	public final String USERNAME_NAME = "userName";
-	public final String ACCOUNT_NAME = "account";
+	public static final String TOKEN_NAME = "token";
+	public static final String PASSWORD_NAME = "password";
+	public static final String USERNAME_NAME = "userName";
+	public static final String ACCOUNT_NAME = "account";
 
 	public static final String ORIGIN_KEY = "Origin";
 	public static final String ORIGIN_VAL = "http://yunpan.360.cn";

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/check/UserCheckLoginConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/check/UserCheckLoginConst.java
@@ -4,7 +4,7 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class UserCheckLoginConst extends BaseConst {
 	
-	public final String URI_PATH = "http://yunpan.360.cn/my/index/";
+	public static final String URI_PATH = "http://yunpan.360.cn/my/index/";
 
 	public static final String QID_NAME = "qid";
 

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/info/UserInfoConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/info/UserInfoConst.java
@@ -4,7 +4,7 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class UserInfoConst extends BaseConst {
 	
-	public final String URI_PATH = "http://login.360.cn/";
+	public static final String URI_PATH = "http://login.360.cn/";
 
 	public static final String QID_NAME = "qid";
 	public static final String METHOD_KEY = "m";

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/signin/UserSigninConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/signin/UserSigninConst.java
@@ -4,18 +4,18 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class UserSigninConst extends BaseConst {
 	
-	public final String URI_PATH = "/user/signin/";
+	public static final String URI_PATH = "/user/signin/";
 
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String QID_NAME = "qid";
-	public final String METHOD_KEY = "method";
+	public static final String QID_NAME = "qid";
+	public static final String METHOD_KEY = "method";
 	public static final String METHOD_VAL = "signin";
 
 	public static final String T_NAME = "t";
-	public final String AJAX_KEY = "1";
+	public static final String AJAX_KEY = "1";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/size/UserSizeConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/size/UserSizeConst.java
@@ -4,7 +4,7 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class UserSizeConst extends BaseConst {
 	
-	public final String URI_PATH = "/user/getsize/?ajax=1";
+	public static final String URI_PATH = "/user/getsize/?ajax=1";
 
 	@Override
 	public String getUriPath() {

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/token/UserTokenConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/token/UserTokenConst.java
@@ -4,15 +4,15 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class UserTokenConst extends BaseConst {
 	
-	public final String URI_PATH = "https://login.360.cn/";
+	public static final String URI_PATH = "https://login.360.cn/";
 
-	public final String REQUESTSCEMA_KEY = "requestScema";
-	public final String REQUESTSCEMA_VAL = "https";
+	public static final String REQUESTSCEMA_KEY = "requestScema";
+	public static final String REQUESTSCEMA_VAL = "https";
 	
-	public final String M_KEY = "m";
-	public final String M_VAL = "getToken";
+	public static final String M_KEY = "m";
+	public static final String M_VAL = "getToken";
 	
-	public final String USERNAME_NAME = "userName";
+	public static final String USERNAME_NAME = "userName";
 
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1170 - “Public constants and fields initialized at declaration should be "static final" rather than merely "final"”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1170
 Please let me know if you have any questions.
Fevzi Ozgul
