### PR TITLE
Fixing squid: S1845 Methods and field names should not be the same or differ only by capitalization

### DIFF
--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/info/UserInfo.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/info/UserInfo.java
@@ -7,7 +7,7 @@ public class UserInfo extends BaseDes {
 
 	private Long timestamp;
 	private String qid;
-	private String username;
+	private String username1;
 	private String nickname;
 	private String login_email;
 	private String userName;
@@ -36,12 +36,12 @@ public class UserInfo extends BaseDes {
 		this.qid = qid;
 	}
 
-	public String getUsername() {
-		return username;
+	public String getUsername1() {
+		return username1;
 	}
 
-	public void setUsername(String username) {
-		this.username = username;
+	public void setUsername1(String username1) {
+		this.username1 = username1;
 	}
 
 	public String getNickname() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1845 - “Methods and field names should not be the same or differ only by capitalization”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1845
 Please let me know if you have any questions.
Fevzi Ozgul
