### PR TITLE
Fixing suid S1444 pubic static fields should be constant

### DIFF
--- a/src/main/java/com/dounine/clouddisk360/parser/AuthTokenParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/AuthTokenParser.java
@@ -26,7 +26,7 @@ public class AuthTokenParser extends
 	
 	private static final Logger LOGGER = LoggerFactory.getLogger(AuthTokenParser.class);
 
-	public static Map<String, AuthTokenParser> authTokenParsers = new ConcurrentHashMap();
+	public static final Map<String, AuthTokenParser> authTokenParsers = new ConcurrentHashMap();
 
 	public AuthTokenParser() {
 		super();

--- a/src/main/java/com/dounine/clouddisk360/parser/DifferPressParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/DifferPressParser.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class DifferPressParser extends
 		BaseParser<HttpGet, DifferPress, DifferPressConst, DifferPressParameter, DifferPressRequestInterceptor, DifferPressResponseHandle, DifferPressParser> {
 
-	public static Map<String, DifferPressParser> DIFFER_PRESS_PARSERS = new ConcurrentHashMap();
+	public static final Map<String, DifferPressParser> DIFFER_PRESS_PARSERS = new ConcurrentHashMap();
 	private Captcha captcha;
 	private CaptchaParser captchaParser;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1444 - “""public static"" fields should be constant”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1444
 Please let me know if you have any questions.
Fevzi Ozgul
