### PR TITLE
Fixing squid: S1148 Throwable.printStackTrace(...) should not be called

### DIFF
--- a/src/main/java/com/dounine/clouddisk360/captthread/CaptThread.java
+++ b/src/main/java/com/dounine/clouddisk360/captthread/CaptThread.java
@@ -77,7 +77,7 @@ public class CaptThread implements Runnable{
 				}
 			}while (returnExist);
 		} catch (InterruptedException e) {
-			e.printStackTrace();
+			LOGGER.error("Exception",e);
 		}
 
 		if (null == cValidator) {

--- a/src/main/java/com/dounine/clouddisk360/captthread/CaptchaThreadValidator.java
+++ b/src/main/java/com/dounine/clouddisk360/captthread/CaptchaThreadValidator.java
@@ -148,7 +148,7 @@ public class CaptchaThreadValidator implements Runnable {
                 }
 
             } catch (InterruptedException e) {
-                e.printStackTrace();
+               LOGGER.error("Exception",e);
             }
         }
     }

--- a/src/main/java/com/dounine/clouddisk360/parser/AuthTokenParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/AuthTokenParser.java
@@ -46,7 +46,7 @@ public class AuthTokenParser extends
 			try {
 				httpGet = new HttpGet(differPress.getRedirectUrl().build());
 			} catch (URISyntaxException e) {
-				e.printStackTrace();
+				LOGGER.error("Exception",e);
 			}
 		}
 		return httpGet;

--- a/src/main/java/com/dounine/clouddisk360/parser/BaseParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/BaseParser.java
@@ -129,15 +129,15 @@ public abstract class BaseParser<Method extends HttpRequest, M extends BaseDes, 
                 } catch (CloudDiskException e) {
                     this.cloudDiskException = e;
                 } catch (InstantiationException | IllegalAccessException e) {
-                    e.printStackTrace();
+                    LOGGER.error("Error",e);;
                 } catch (NoSuchMethodException e) {
-                    e.printStackTrace();
+                	LOGGER.error("Error",e);;
                 } catch (SecurityException e) {
-                    e.printStackTrace();
+                	LOGGER.error("Error",e);;
                 } catch (IllegalArgumentException e) {
-                    e.printStackTrace();
+                	LOGGER.error("Error",e);;
                 } catch (InvocationTargetException e) {
-                    e.printStackTrace();
+                	LOGGER.error("Error",e);;
                 }
                 if (this.hasException()) {//有异常程序返回
                     return;
@@ -155,11 +155,11 @@ public abstract class BaseParser<Method extends HttpRequest, M extends BaseDes, 
             this.requestMethod = (HttpRequest) requestMethodClazz.newInstance();
             CONST = (C) baseconstMethodClazz.newInstance();
         } catch (InstantiationException | IllegalAccessException e) {
-            e.printStackTrace();
+        	LOGGER.error("Error",e);;
         } catch (IllegalArgumentException e) {
-            e.printStackTrace();
+        	LOGGER.error("Error",e);;
         } catch (InvocationTargetException e) {
-            e.printStackTrace();
+        	LOGGER.error("Error",e);;
         }
     }
 
@@ -251,9 +251,9 @@ public abstract class BaseParser<Method extends HttpRequest, M extends BaseDes, 
             m = mClazz.newInstance();
             m.setCddmsg(cloudDiskException.getMessage());
         } catch (InstantiationException e) {
-            e.printStackTrace();
+        	LOGGER.error("Error",e);;
         } catch (IllegalAccessException e) {
-            e.printStackTrace();
+        	LOGGER.error("Error",e);;
         }
         return m;
     }
@@ -316,7 +316,7 @@ public abstract class BaseParser<Method extends HttpRequest, M extends BaseDes, 
             final URIBuilder uriBuilder =new URIBuilder(getRedSchmemHost());
             return uriBuilder.getHost();
         } catch (URISyntaxException e) {
-            e.printStackTrace();
+        	LOGGER.error("Error",e);
         }
         return null;
     }

--- a/src/main/java/com/dounine/clouddisk360/parser/CaptchaParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/CaptchaParser.java
@@ -6,6 +6,8 @@ import com.dounine.clouddisk360.parser.deserializer.captcha.*;
 import com.dounine.clouddisk360.parser.deserializer.login.LoginUserToken;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URISyntaxException;
 
@@ -13,7 +15,7 @@ import java.net.URISyntaxException;
 @DependResult(result = Captcha.class, customInit = false)
 public class CaptchaParser extends
 		BaseParser<HttpGet, Captcha, CaptchaConst, CaptchaParameter, CaptchaRequestInterceptor, CaptchaResponseHandle, CaptchaParser> {
-	
+	private static final Logger LOGGER = LoggerFactory.getLogger(CaptchaParser.class);
 	public CaptchaParser() {
 		super();
 	}
@@ -36,7 +38,7 @@ public class CaptchaParser extends
 			uri.setParameter(CONST.CAPTCHAAPP_KEY, CONST.CAPTCHAAPP_VAL);
 			request = new HttpGet(uri.build());
 		} catch (URISyntaxException e) {
-			e.printStackTrace();
+			LOGGER.error("Error",e);
 		}
 		return request;
 	}

--- a/src/main/java/com/dounine/clouddisk360/parser/DifferPressParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/DifferPressParser.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @DependResult(customInit = false, result = DifferPress.class)
 public class DifferPressParser extends
 		BaseParser<HttpGet, DifferPress, DifferPressConst, DifferPressParameter, DifferPressRequestInterceptor, DifferPressResponseHandle, DifferPressParser> {
-
+	
 	public static Map<String, DifferPressParser> DIFFER_PRESS_PARSERS = new ConcurrentHashMap();
 	private Captcha captcha;
 	private CaptchaParser captchaParser;
@@ -61,7 +61,7 @@ public class DifferPressParser extends
 			uri.setParameter(CONST.KEEPALIVE_KEY, CONST.KEEPALIVE_VAL);
 			request = new HttpGet(uri.build());
 		} catch (URISyntaxException e) {
-			e.printStackTrace();
+			LOGGER.error("Error",e);
 		}
 		return request;
 	}
@@ -146,7 +146,7 @@ public class DifferPressParser extends
 		try {
 			return httpClient.execute(request, responseHandler, httpClientContext);
 		} catch (IOException e) {
-			e.printStackTrace();
+			LOGGER.error("Error",e);
 		}
 		final DifferPress differPress = new DifferPress();
 		differPress.setCddmsg(userCheckLogin.getCddmsg());

--- a/src/main/java/com/dounine/clouddisk360/parser/JSONBinary.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/JSONBinary.java
@@ -45,7 +45,7 @@ public class JSONBinary {
 				jsonWriter.flush();
 				LOGGER.info("文件 { " + file.getName() + " } 写入位置" + file.getAbsolutePath());
 			} catch (IOException e) {
-				e.printStackTrace();
+				LOGGER.error("Error",e);
 			} finally {
 				try {
 					if(null!=fileWriter){
@@ -55,7 +55,7 @@ public class JSONBinary {
 						jsonWriter.close();
 					}
 				} catch (IOException e) {
-					e.printStackTrace();
+					LOGGER.error("Error",e);
 				}
 			}
 		}
@@ -70,7 +70,7 @@ public class JSONBinary {
 				try {
 					file.createNewFile();
 				} catch (IOException e) {
-					e.printStackTrace();
+					LOGGER.error("Error",e);
 				}
 			}else{
 				try {
@@ -85,7 +85,7 @@ public class JSONBinary {
 							t = jsonReader.readObject(clazz);
 							jsonReader.endObject();
 						} catch (IOException e) {
-							e.printStackTrace();
+							LOGGER.error("Error",e);
 						} finally {
 							if(null!=fileReader){
 								fileReader.close();
@@ -97,7 +97,7 @@ public class JSONBinary {
 						return t;
 					}
 				} catch (IOException e) {
-					e.printStackTrace();
+					LOGGER.error("Error",e);
 				}
 			}
 			return null;
@@ -121,7 +121,7 @@ public class JSONBinary {
 				jsonWriter.endArray();
 				jsonWriter.flush();
 			} catch (IOException e) {
-				e.printStackTrace();
+				LOGGER.error("Error",e);
 			} finally {
 				try {
 					if(null!=fileWriter){
@@ -131,7 +131,7 @@ public class JSONBinary {
 						jsonWriter.close();
 					}
 				} catch (IOException e) {
-					e.printStackTrace();
+					LOGGER.error("Error",e);
 				}
 			}
 		}
@@ -155,13 +155,13 @@ public class JSONBinary {
 				}
 				jsonReader.endArray();
 			} catch (IOException e) {
-				e.printStackTrace();
+				LOGGER.error("Error",e);
 			} finally {
 				if(null!=fileReader){
 					try {
 						fileReader.close();
 					} catch (IOException e) {
-						e.printStackTrace();
+						LOGGER.error("Error",e);
 					}
 				}
 				if(null!=jsonReader){

--- a/src/main/java/com/dounine/clouddisk360/parser/UserInfoParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/UserInfoParser.java
@@ -13,6 +13,8 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -22,7 +24,7 @@ import java.net.URISyntaxException;
 @DependResult(customInit = false, result = UserInfo.class)
 public class UserInfoParser extends
 		BaseParser<HttpGet, UserInfo, UserInfoConst, UserInfoParameter, UserInfoRequestInterceptor, UserInfoResponseHandle,UserInfoParser> {
-
+	private static final Logger LOGGER = LoggerFactory.getLogger(UserInfoParser.class);
 	public UserInfoParser(){
 		super();
 	}
@@ -51,7 +53,7 @@ public class UserInfoParser extends
 			request.setConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.NETSCAPE).build());
 			return request;
 		} catch (URISyntaxException e) {
-			e.printStackTrace();
+			LOGGER.error("Error",e);
 		}
 		return null;
 	}

--- a/src/main/java/com/dounine/clouddisk360/parser/UserSizeParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/UserSizeParser.java
@@ -16,7 +16,7 @@ import java.net.URISyntaxException;
 @Dependency(depends={AuthTokenParser.class})
 public class UserSizeParser extends
 		BaseParser<HttpGet, UserSize, UserSizeConst, UserSizeParameter, UserSizeRequestInterceptor, UserSizeResponseHandle,UserSizeParser> {
-
+	private static final Logger LOGGER = LoggerFactory.getLogger(UserSizeParser.class);
 	public UserSizeParser(){
 		super();
 	}
@@ -39,7 +39,7 @@ public class UserSizeParser extends
 			uri.setParameter("t", TimeUtil.getTimeLenth(10));
 			return new HttpGet(uri.build());
 		} catch (URISyntaxException e) {
-			e.printStackTrace();
+			LOGGER.error("Error",e);
 		}
 		return null;
 	}

--- a/src/main/java/com/dounine/clouddisk360/parser/UserTokenParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/UserTokenParser.java
@@ -5,13 +5,15 @@ import com.dounine.clouddisk360.parser.deserializer.login.LoginUserToken;
 import com.dounine.clouddisk360.parser.deserializer.user.token.*;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URISyntaxException;
 
 @Parse("登录令牌")
 public class UserTokenParser extends
 		BaseParser<HttpGet, UserToken, UserTokenConst, UserTokenParameter, UserTokenRequestInterceptor, UserTokenResponseHandle,UserTokenParser> {
-
+	private static final Logger LOGGER = LoggerFactory.getLogger(UserTokenParser.class);
 	public UserTokenParser(){
 		super();
 	}
@@ -32,7 +34,7 @@ public class UserTokenParser extends
 			uri.setParameter(CONST.USERNAME_NAME, loginUserToken.getAccount());
 			request = new HttpGet(uri.build());
 		} catch (URISyntaxException e) {
-			e.printStackTrace();
+			LOGGER.error("Error",e);
 		}
 		return request;
 	}

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/differpre/DifferPressResponseHandle.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/differpre/DifferPressResponseHandle.java
@@ -1,6 +1,7 @@
 package com.dounine.clouddisk360.parser.deserializer.differpre;
 
 import com.dounine.clouddisk360.parser.DifferPressParser;
+import com.dounine.clouddisk360.parser.UserTokenParser;
 import com.dounine.clouddisk360.parser.deserializer.BaseResponseHandle;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
@@ -8,13 +9,15 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.utils.URIBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 
 public class DifferPressResponseHandle extends BaseResponseHandle<DifferPress, DifferPressParser>
 		implements ResponseHandler<DifferPress> {
-
+	private static final Logger LOGGER = LoggerFactory.getLogger(DifferPressResponseHandle.class);
 	public DifferPressResponseHandle(final DifferPressParser parse) {
 		super(parse);
 	}
@@ -38,7 +41,7 @@ public class DifferPressResponseHandle extends BaseResponseHandle<DifferPress, D
 				parse.getDependencys().put(DifferPress.class,differPress);
 			}
 		} catch (URISyntaxException e) {
-			e.printStackTrace();
+			LOGGER.error("Error",e);
 		}
 		executeAfter(response);
 		return differPress;

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/passport/PassportResponseHandle.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/passport/PassportResponseHandle.java
@@ -2,6 +2,7 @@ package com.dounine.clouddisk360.parser.deserializer.passport;
 
 import com.dounine.clouddisk360.parser.PassportParser;
 import com.dounine.clouddisk360.parser.deserializer.BaseResponseHandle;
+import com.dounine.clouddisk360.parser.deserializer.differpre.DifferPressResponseHandle;
 import com.dounine.clouddisk360.parser.deserializer.login.LoginConst;
 import com.dounine.clouddisk360.parser.deserializer.login.LoginUserToken;
 import com.dounine.clouddisk360.store.BasePathCommon;
@@ -10,12 +11,14 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.ResponseHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 
 public class PassportResponseHandle extends BaseResponseHandle<Passport, PassportParser>
 		implements ResponseHandler<Passport> {
-
+	private static final Logger LOGGER = LoggerFactory.getLogger(PassportResponseHandle.class);
 	public PassportResponseHandle(final PassportParser parse) {
 		super(parse);
 	}
@@ -42,7 +45,7 @@ public class PassportResponseHandle extends BaseResponseHandle<Passport, Passpor
 		try {
 			is = entity.getContent();
 		} catch (UnsupportedOperationException | IOException e2) {
-			e2.printStackTrace();
+			LOGGER.error("Error",e2);
 		}
 		try {
 			final LoginUserToken loginUser = parse.getLoginUserToken();
@@ -53,9 +56,9 @@ public class PassportResponseHandle extends BaseResponseHandle<Passport, Passpor
 			}
 			FileUtils.copyInputStreamToFile(is,file);
 		} catch (FileNotFoundException e1) {
-			e1.printStackTrace();
+			LOGGER.error("Error",e1);
 		} catch (IOException e) {
-			e.printStackTrace();
+			LOGGER.error("Error",e);
 		}
 	}
 

--- a/src/main/java/com/dounine/clouddisk360/pool/PoolingHttpClientConnection.java
+++ b/src/main/java/com/dounine/clouddisk360/pool/PoolingHttpClientConnection.java
@@ -59,7 +59,7 @@ public class PoolingHttpClientConnection {
 					.register("https", sslsf).register("http", new PlainConnectionSocketFactory()).build();
 			CM = new PoolingHttpClientConnectionManager(socketFactoryRegistry);
 		} catch (Exception e) {
-			e.printStackTrace();
+			LOGGER.error("Error",e);
 		}
 
 		CM.setMaxTotal(200);// 设置最大连接数
@@ -84,11 +84,11 @@ public class PoolingHttpClientConnection {
 			} catch (ConnectTimeoutException e) {
 				LOGGER.error("连接超时");
 			} catch (InterruptedException e) {
-				e.printStackTrace();
+				LOGGER.error("Error",e);
 			} catch (ExecutionException e) {
-				e.printStackTrace();
+				LOGGER.error("Error",e);
 			} catch (IOException e) {
-				e.printStackTrace();
+				LOGGER.error("Error",e);
 			}
 		}
 

--- a/src/main/java/com/dounine/clouddisk360/store/CookieStoreUT.java
+++ b/src/main/java/com/dounine/clouddisk360/store/CookieStoreUT.java
@@ -76,15 +76,15 @@ public class CookieStoreUT {
 			reader.endArray();
 
 		} catch (FileNotFoundException e) {
-			e.printStackTrace();
+			LOGGER.error("Error",e);
 		} catch (IOException e) {
-			e.printStackTrace();
+			LOGGER.error("Error",e);
 		} finally {
 			if(null!=fileReader){
 				try {
 					fileReader.close();
 				} catch (IOException e) {
-					e.printStackTrace();
+					LOGGER.error("Error",e);
 				}
 			}
 			if(null!=reader){
@@ -186,22 +186,22 @@ public class CookieStoreUT {
 				cookieStore.getCookies().clear();
 				cookieStore.getCookies().addAll(writeDiskCookies);
 			} catch (FileNotFoundException e) {
-				e.printStackTrace();
+				LOGGER.error("Error",e);
 			} catch (IOException e) {
-				e.printStackTrace();
+				LOGGER.error("Error",e);
 			} finally {
 				if(null!=fileWriter){
 					try {
 						fileWriter.close();
 					} catch (IOException e) {
-						e.printStackTrace();
+						LOGGER.error("Error",e);
 					}
 				}
 				if(null!=writer){
 					try {
 						writer.close();
 					} catch (IOException e) {
-						e.printStackTrace();
+						LOGGER.error("Error",e);
 					}
 				}
 			}

--- a/src/main/java/com/dounine/clouddisk360/store/UserStoreUT.java
+++ b/src/main/java/com/dounine/clouddisk360/store/UserStoreUT.java
@@ -28,9 +28,9 @@ public class UserStoreUT {
 			writer.close();
 			LOGGER.info(String.format("360云盘用户登录信息保存路径 [ %s ] ", cookiesFile.getAbsolutePath()));
 		} catch (FileNotFoundException e) {
-			e.printStackTrace();
+			LOGGER.error("Error",e);
 		} catch (IOException e) {
-			e.printStackTrace();
+			LOGGER.error("Error",e);
 		}
 	}
 }

--- a/src/main/java/com/dounine/clouddisk360/util/MD5Util.java
+++ b/src/main/java/com/dounine/clouddisk360/util/MD5Util.java
@@ -4,14 +4,19 @@ import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-public class MD5Util {
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.dounine.clouddisk360.store.UserStoreUT;
+
+public class MD5Util {
+	private static final Logger LOGGER = LoggerFactory.getLogger(MD5Util.class);
     public final static String MD5(final String s) {
         byte[] btInput = null;
         try {
             btInput = s.getBytes("utf-8");
         } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
+        	LOGGER.error("Error",e);
         }
         return MD5(btInput);
     }
@@ -22,7 +27,7 @@ public class MD5Util {
             md5 = MessageDigest.getInstance("MD5");
         } catch (Exception e) {
             System.out.println(e.toString());
-            e.printStackTrace();
+            LOGGER.error("Error",e);
             return "";
         }
         final char[] charArray = inStr.toCharArray();
@@ -51,7 +56,7 @@ public class MD5Util {
             messageDigest.reset();
             messageDigest.update(data);
         } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
+        	LOGGER.error("Error",e);
         }
         final byte[] byteArray = messageDigest.digest();
         final StringBuffer md5StrBuff = new StringBuffer();

--- a/src/main/java/com/dounine/clouddisk360/util/URLUtil.java
+++ b/src/main/java/com/dounine/clouddisk360/util/URLUtil.java
@@ -3,13 +3,16 @@ package com.dounine.clouddisk360.util;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 
-public class URLUtil {
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+public class URLUtil {
+	private static final Logger LOGGER = LoggerFactory.getLogger(URLUtil.class);
 	public final static String decode(final String code){
 		try {
 			return URLDecoder.decode(code,"utf-8");
 		} catch (UnsupportedEncodingException e) {
-			e.printStackTrace();
+			LOGGER.error("Error",e);
 		}
 		return null;
 	}


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1148 - “Throwable.printStackTrace(...) should not be called”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1148
 Please let me know if you have any questions.
Fevzi Ozgul
