### PR TITLE
Fixing suid: ClassVariableVisibilityCheck Class variable fields shoud not have public accessibility

### DIFF
--- a/src/main/java/com/dounine/clouddisk360/parser/BaseParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/BaseParser.java
@@ -61,11 +61,11 @@ public abstract class BaseParser<Method extends HttpRequest, M extends BaseDes, 
     protected HttpClientContext httpClientContext = new HttpClientContext();
     protected HttpClient httpClient;
 
-    public RequestInterceptor requestInterceptor;
-    public C CONST;
-    public HttpRequest requestMethod;
-    public ResponseHandler<M> responseHandler;
-    public Parameter parameter;
+    protected RequestInterceptor requestInterceptor;
+    protected C CONST;
+    protected HttpRequest requestMethod;
+    protected ResponseHandler<M> responseHandler;
+    protected Parameter parameter;
     protected String uriPath;
     protected Class<M> mClazz;
     /**

--- a/src/main/java/com/dounine/clouddisk360/parser/DifferPressParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/DifferPressParser.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class DifferPressParser extends
 		BaseParser<HttpGet, DifferPress, DifferPressConst, DifferPressParameter, DifferPressRequestInterceptor, DifferPressResponseHandle, DifferPressParser> {
 
-	public static Map<String, DifferPressParser> DIFFER_PRESS_PARSERS = new ConcurrentHashMap();
+	public static final Map<String, DifferPressParser> DIFFER_PRESS_PARSERS = new ConcurrentHashMap();
 	private Captcha captcha;
 	private CaptchaParser captchaParser;
 

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/BaseResponseHandle.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/BaseResponseHandle.java
@@ -24,8 +24,8 @@ public class BaseResponseHandle<M extends BaseDes, P> implements ResponseHandler
 	public static final Pattern VAL_PAT = Pattern.compile("[{].*[}]");
 	public static final Pattern ERR_VAL_PAT = Pattern.compile("errno=\\d{2,}&errmsg=.{2,}[&]");//查找错误信息
 
-	public P parse;
-	public Class<M> entityClass;
+	protected P parse;
+	protected Class<M> entityClass;
 
 	@SuppressWarnings("unchecked")
 	public BaseResponseHandle(final P parse) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:ClassVariableVisibilityCheck - “Class variable fields shoud not have public accessibility ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
 Please let me know if you have any questions.
Fevzi Ozgul
