### PR TITLE
Fixing squid: S1213 The members of an interface declaration or class should appear in a pre-defined order 

### DIFF
--- a/src/main/java/com/dounine/clouddisk360/captthread/CaptchaThreadValidator.java
+++ b/src/main/java/com/dounine/clouddisk360/captthread/CaptchaThreadValidator.java
@@ -14,11 +14,12 @@ public class CaptchaThreadValidator implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(CaptchaThreadValidator.class);
     public static final int timeoutMin = 10 * 60;
     private static final String ACCOUNT_NOT_NULL = "account not empty";
-
+    private static final CaptchaThreadValidator captchaThreadValidator;
+    private static Map<String, CaptchaValidator> captchaValidators = new ConcurrentHashMap(100);
+    
     private CaptchaThreadValidator() {
     }
 
-    private static final CaptchaThreadValidator captchaThreadValidator;
 
     static {
         captchaThreadValidator = new CaptchaThreadValidator();
@@ -29,7 +30,7 @@ public class CaptchaThreadValidator implements Runnable {
         return captchaThreadValidator;
     }
 
-    private static Map<String, CaptchaValidator> captchaValidators = new ConcurrentHashMap(100);
+    
 
     public static boolean isTimeout(final String account) {
         return isTimeout(account, false);

--- a/src/main/java/com/dounine/clouddisk360/parser/BaseParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/BaseParser.java
@@ -75,6 +75,25 @@ public abstract class BaseParser<Method extends HttpRequest, M extends BaseDes, 
     protected CloudDiskException cloudDiskException;
     protected LocalDateTime createDateTime = LocalDateTime.now();
 
+    public BaseParser() {
+        inits();
+    }
+
+    public BaseParser(final LoginUserToken loginUser) {
+        if (null == loginUserToken) {
+            if (null == loginUser) {
+                throw new CloudDiskException("loginUserToken 不能为空");
+            }
+            if (StringUtils.isBlank(loginUser.getAccount()) || StringUtils.isBlank(loginUser.getPassword())) {
+                throw new CloudDiskException("loginUserToken (用户名/密码)不能为空");
+            }
+        }
+        this.cookieStoreUT.setLoginUserToken(loginUser);
+        //httpClientContext.setUserToken(loginUser);
+        this.loginUserToken = loginUser;
+        inits();
+    }
+    
     public BaseParser dependsCustomInit(final Parser parser, final BaseParser baseParser) {
         return baseParser;
     }
@@ -163,24 +182,7 @@ public abstract class BaseParser<Method extends HttpRequest, M extends BaseDes, 
         }
     }
 
-    public BaseParser() {
-        inits();
-    }
-
-    public BaseParser(final LoginUserToken loginUser) {
-        if (null == loginUserToken) {
-            if (null == loginUser) {
-                throw new CloudDiskException("loginUserToken 不能为空");
-            }
-            if (StringUtils.isBlank(loginUser.getAccount()) || StringUtils.isBlank(loginUser.getPassword())) {
-                throw new CloudDiskException("loginUserToken (用户名/密码)不能为空");
-            }
-        }
-        this.cookieStoreUT.setLoginUserToken(loginUser);
-        //httpClientContext.setUserToken(loginUser);
-        this.loginUserToken = loginUser;
-        inits();
-    }
+   
 
     /**
      * 把parse数据平滑过来

--- a/src/main/java/com/dounine/clouddisk360/parser/DifferPressParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/DifferPressParser.java
@@ -36,8 +36,9 @@ import java.util.concurrent.ConcurrentHashMap;
 @DependResult(customInit = false, result = DifferPress.class)
 public class DifferPressParser extends
 		BaseParser<HttpGet, DifferPress, DifferPressConst, DifferPressParameter, DifferPressRequestInterceptor, DifferPressResponseHandle, DifferPressParser> {
-
-	public static Map<String, DifferPressParser> DIFFER_PRESS_PARSERS = new ConcurrentHashMap();
+	
+	public static final Logger LOGGER = LoggerFactory.getLogger(DifferPressParser.class);
+	public static Map<String, DifferPressParser> DIFFER_PRESS_PARSERS = new ConcurrentHashMap();	
 	private Captcha captcha;
 	private CaptchaParser captchaParser;
 
@@ -49,7 +50,7 @@ public class DifferPressParser extends
 		super(loginUser);
 	}
 
-	public static final Logger LOGGER = LoggerFactory.getLogger(DifferPressParser.class);
+	
 
 	@Override
 	public HttpGet initRequest(final DifferPressParameter parameter) {

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/create/FileCreateConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/create/FileCreateConst.java
@@ -3,7 +3,13 @@ package com.dounine.clouddisk360.parser.deserializer.file.create;
 import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileCreateConst extends BaseConst {
-
+	
+	public static final String REQUESTSCEMA_KEY = "requestScema";
+	public static final String REQUESTSCEMA_VAL = "https";
+	public static final String M_KEY = "m";
+	public static final String M_VAL = "getToken";
+	public static final String USERNAME_NAME = "userName";
+	public final String PATH_NAME = "path";
 	public final String URI_PATH = "/file/mkdir";
 
 	@Override
@@ -11,14 +17,6 @@ public final class FileCreateConst extends BaseConst {
 		return URI_PATH;
 	}
 
-	public static final String REQUESTSCEMA_KEY = "requestScema";
-	public static final String REQUESTSCEMA_VAL = "https";
-
-	public static final String M_KEY = "m";
-	public static final String M_VAL = "getToken";
-
-	public static final String USERNAME_NAME = "userName";
-
-	public final String PATH_NAME = "path";
+	
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/download/dladdress/FileDownloadAddressConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/download/dladdress/FileDownloadAddressConst.java
@@ -5,13 +5,14 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileDownloadAddressConst extends BaseConst {
 
 	public final String URI_PATH = "/file/download/";
-
+	public final String NID_NAME = "nid";
+	public final String FNAME_NAME = "fname";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String NID_NAME = "nid";
-	public final String FNAME_NAME = "fname";
+	
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/exist/FileExistConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/exist/FileExistConst.java
@@ -5,13 +5,14 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileExistConst extends BaseConst {
 
 	public final String URI_PATH = "/file/detectFileExists";
-
+	public final String DIR_NAME = "dir";
+	public final String FNAME_NAME = "fname[]";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String DIR_NAME = "dir";
-	public final String FNAME_NAME = "fname[]";
+	
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/history/FileHistoryConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/history/FileHistoryConst.java
@@ -5,16 +5,17 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileHistoryConst extends BaseConst {
 
 	public final String URI_PATH = "/fHistory/getFileHistory/";
-
-	@Override
-	public String getUriPath() {
-		return URI_PATH;
-	}
-
 	public final String NID_NAME = "nid";
 	public final String HIS_NID_NAME = "his_nid";
 	public final String START_NAME = "start";
 	public final String NUM_NAME = "num";
 	public final String SOURCE_NAME = "source";
+	
+	@Override
+	public String getUriPath() {
+		return URI_PATH;
+	}
+
+	
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/history/restore/FileRestoreConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/history/restore/FileRestoreConst.java
@@ -5,14 +5,15 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileRestoreConst extends BaseConst {
 	
 	public final String URI_PATH = "/fHistory/restore";
-
+	public final String NID_NAME = "nid";
+	public final String ID_NAME = "id";
+	public final String SOURCE_NAME = "source";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String NID_NAME = "nid";
-	public final String ID_NAME = "id";
-	public final String SOURCE_NAME = "source";
+	
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/list/FileListConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/list/FileListConst.java
@@ -4,26 +4,27 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileListConst extends BaseConst {
 
+	
+	public static final String REQUESTSCEMA_KEY = "requestScema";
+	public static final String REQUESTSCEMA_VAL = "https";
+	public static final String FIELD_VAL = "file_name";
+	public static final String PAGE_NAME = "page";
+	public static final String M_KEY = "m";
+	public static final String M_VAL = "getToken";
+	public static final String USERNAME_NAME = "userName";
+	
 	public final String URI_PATH = "/file/list";
-
+	public final String TYPE_NAME = "type";
+	public final String PATH_NAME = "path";
+	public final String ORDER_NAME = "order";
+	public final String FIELD_KEY = "field";
+	public final String PAGE_SIZE_NAME = "page_size";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public static final String REQUESTSCEMA_KEY = "requestScema";
-	public static final String REQUESTSCEMA_VAL = "https";
-
-	public static final String M_KEY = "m";
-	public static final String M_VAL = "getToken";
-
-	public static final String USERNAME_NAME = "userName";
-	public final String TYPE_NAME = "type";
-	public final String PATH_NAME = "path";
-	public final String ORDER_NAME = "order";
-	public final String FIELD_KEY = "field";
-	public static final String FIELD_VAL = "file_name";
-	public static final String PAGE_NAME = "page";
-	public final String PAGE_SIZE_NAME = "page_size";
+	
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/move/FileMoveConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/move/FileMoveConst.java
@@ -3,16 +3,17 @@ package com.dounine.clouddisk360.parser.deserializer.file.move;
 import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileMoveConst extends BaseConst {
-
+	
+	public static final String NID_NAME = "nid";
 	public final String URI_PATH = "/file/move/";
-
+	public final String PATH_NAME = "path[]";
+	public final String NEWPATH_NAME = "newpath";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String PATH_NAME = "path[]";
-	public final String NEWPATH_NAME = "newpath";
-	public static final String NID_NAME = "nid";
+	
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/move/list/FileListAjaxConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/move/list/FileListAjaxConst.java
@@ -5,14 +5,15 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileListAjaxConst extends BaseConst {
 	
 	public final String URI_PATH = "/file/listAjax";
-
+	public final String PATH_NAME = "path";
+	public final String ID_NAME = "id";
+	public final String NID_NAME = "nid";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String PATH_NAME = "path";
-	public final String ID_NAME = "id";
-	public final String NID_NAME = "nid";
+	
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/recycle/FileRecycleConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/recycle/FileRecycleConst.java
@@ -5,12 +5,13 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileRecycleConst extends BaseConst {
 
 	public final String URI_PATH = "/file/asyncRecycle/";
-
+	public final String PATH_NAME = "path[]";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String PATH_NAME = "path[]";
+	
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/rename/FileRenameConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/rename/FileRenameConst.java
@@ -5,14 +5,15 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileRenameConst extends BaseConst {
 
 	public final String URI_PATH = "/file/rename";
-
+	public final String PATH_NAME = "path";
+	public final String NEWPATH_NAME = "newpath";
+	public final String NID_NAME = "nid";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String PATH_NAME = "path";
-	public final String NEWPATH_NAME = "newpath";
-	public final String NID_NAME = "nid";
+	
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/search/FileSearchConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/search/FileSearchConst.java
@@ -5,14 +5,15 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileSearchConst extends BaseConst {
 
 	public final String URI_PATH = "/file/searchList";
-
+	public final String KEY_NAME = "key";
+	public final String ISFPATH_NAME = "is_fpath";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String KEY_NAME = "key";
-	public final String ISFPATH_NAME = "is_fpath";
+	
 
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/trends/FileTrendsListConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/trends/FileTrendsListConst.java
@@ -5,14 +5,15 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileTrendsListConst extends BaseConst {
 
 	public final String URI_PATH = "/trends/getTrendsList";
-
+	public static final String PATH_NAME = "path";
+	public static final String NEWPATH_NAME = "newpath";
+	public static final String NID_NAME = "nid";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public static final String PATH_NAME = "path";
-	public static final String NEWPATH_NAME = "newpath";
-	public static final String NID_NAME = "nid";
+	
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/upload/addfile/FileAddFileConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/upload/addfile/FileAddFileConst.java
@@ -5,13 +5,14 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileAddFileConst extends BaseConst {
 
 	public final String URI_PATH = "/upload/addfile";
-
+	public final String TK_NAME = "tk";
+	public static final String NID_NAME = "nid";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String TK_NAME = "tk";
-	public static final String NID_NAME = "nid";
+	
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/signin/UserSigninConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/signin/UserSigninConst.java
@@ -4,18 +4,18 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class UserSigninConst extends BaseConst {
 	
+	public static final String METHOD_VAL = "signin";
+	public static final String T_NAME = "t";
 	public final String URI_PATH = "/user/signin/";
-
+	public final String QID_NAME = "qid";
+	public final String METHOD_KEY = "method";
+	public final String AJAX_KEY = "1";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String QID_NAME = "qid";
-	public final String METHOD_KEY = "method";
-	public static final String METHOD_VAL = "signin";
-
-	public static final String T_NAME = "t";
-	public final String AJAX_KEY = "1";
+	
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/size/UserSizeConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/size/UserSizeConst.java
@@ -4,16 +4,16 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class UserSizeConst extends BaseConst {
 	
+	public static final String QID_NAME = "qid";
 	public final String URI_PATH = "/user/getsize/?ajax=1";
-
+	public static final String METHOD_KEY = "method";
+	public static final String METHOD_VAL = "signin";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public static final String QID_NAME = "qid";
-
-	public static final String METHOD_KEY = "method";
-	public static final String METHOD_VAL = "signin";
+	
 
 }

--- a/src/main/java/com/dounine/clouddisk360/store/DomainStoreUT.java
+++ b/src/main/java/com/dounine/clouddisk360/store/DomainStoreUT.java
@@ -6,11 +6,11 @@ import com.dounine.clouddisk360.exception.CloudDiskException;
 
 public class DomainStoreUT {
 
-	private DomainStoreUT() {}
-
 	private static final DomainStoreUT domainStoreUT = new DomainStoreUT();
 	private String domain;
 
+	private DomainStoreUT() {}
+	
 	public static DomainStoreUT getInstance() {
 		return domainStoreUT;
 	}


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1213 - “The members of an interface declaration or class should appear in a pre-defined order ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1213
 Please let me know if you have any questions.
Fevzi Ozgul
