### PR TITLE
Fixing squid:S2142 InterruptedException should not be ignored

### DIFF
--- a/src/main/java/com/dounine/clouddisk360/captthread/CaptThread.java
+++ b/src/main/java/com/dounine/clouddisk360/captthread/CaptThread.java
@@ -78,6 +78,7 @@ public class CaptThread implements Runnable{
 			}while (returnExist);
 		} catch (InterruptedException e) {
 			e.printStackTrace();
+			Thread.currentThread().interrupt();
 		}
 
 		if (null == cValidator) {

--- a/src/main/java/com/dounine/clouddisk360/captthread/CaptchaThreadValidator.java
+++ b/src/main/java/com/dounine/clouddisk360/captthread/CaptchaThreadValidator.java
@@ -149,6 +149,7 @@ public class CaptchaThreadValidator implements Runnable {
 
             } catch (InterruptedException e) {
                 e.printStackTrace();
+                Thread.currentThread().interrupt();
             }
         }
     }

--- a/src/main/java/com/dounine/clouddisk360/pool/IdleConnectionMonitorThread.java
+++ b/src/main/java/com/dounine/clouddisk360/pool/IdleConnectionMonitorThread.java
@@ -29,6 +29,7 @@ public class IdleConnectionMonitorThread extends Thread{
             }  
         } catch (InterruptedException ex) {  
             // terminate  
+        	Thread.currentThread().interrupt();
         }  
     }  
       

--- a/src/main/java/com/dounine/clouddisk360/pool/PoolingHttpClientConnection.java
+++ b/src/main/java/com/dounine/clouddisk360/pool/PoolingHttpClientConnection.java
@@ -87,6 +87,7 @@ public final class PoolingHttpClientConnection {
 				LOGGER.error("连接超时");
 			} catch (InterruptedException e) {
 				e.printStackTrace();
+				Thread.currentThread().interrupt();
 			} catch (ExecutionException e) {
 				e.printStackTrace();
 			} catch (IOException e) {


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2142 - “ InterruptedException should not be ignored”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2142
 Please let me know if you have any questions.
Fevzi Ozgul
