### PR TITLE
Fixing squid: S1149  Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/src/main/java/com/dounine/clouddisk360/util/MD5Util.java
+++ b/src/main/java/com/dounine/clouddisk360/util/MD5Util.java
@@ -34,7 +34,7 @@ public final class MD5Util {
             byteArray[i] = (byte) charArray[i];
         }
         final byte[] md5Bytes = md5.digest(byteArray);
-        final StringBuffer hexValue = new StringBuffer();
+        final StringBuilder hexValue = new StringBuilder();
         for (int i = 0; i < md5Bytes.length; i++) {
             final int val = ((int) md5Bytes[i]) & 0xff;
             if (val < 16) {
@@ -56,7 +56,7 @@ public final class MD5Util {
             e.printStackTrace();
         }
         final byte[] byteArray = messageDigest.digest();
-        final StringBuffer md5StrBuff = new StringBuffer();
+        final StringBuilder md5StrBuff = new StringBuilder();
         for (int i = 0; i < byteArray.length; i++) {
             if (Integer.toHexString(0xFF & byteArray[i]).length() == 1) {
                 md5StrBuff.append('0').append(Integer.toHexString(0xFF & byteArray[i]));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1149
 Please let me know if you have any questions.
Fevzi Ozgul
