### PR TITLE
Fixing squid:S00119 Type parameter names should comply with a naming convention

### DIFF
--- a/src/main/java/com/dounine/clouddisk360/parser/BaseParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/BaseParser.java
@@ -40,7 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public abstract class BaseParser<Method extends HttpRequest, M extends BaseDes, C extends BaseConst, Parameter extends BaseParameter, RequestInterceptor extends BaseRequestInterceptor<C,Parser>, ResponseHandle, Parser extends BaseParser>
+public abstract class BaseParser<M1 extends HttpRequest, M extends BaseDes, C extends BaseConst, Parameter extends BaseParameter, RequestInterceptor extends BaseRequestInterceptor<C,Parser>, ResponseHandle, Parser extends BaseParser>
         extends JSONBinary implements IBaseParser{
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BaseParser.class);
@@ -79,20 +79,20 @@ public abstract class BaseParser<Method extends HttpRequest, M extends BaseDes, 
         return baseParser;
     }
 
-    public <TT> TT getDependResult(final Class<TT> depend) {
-        TT tt = null;
+    public <T> T getDependResult(final Class<T> depend) {
+        T tt = null;
         final Object baseDes = this.dependencys.get(depend);
         if (null != baseDes) {
-            tt = (TT) baseDes;
+            tt = (T) baseDes;
         }
         return tt;
     }
 
-    public <TT> TT getDependAccountResult(final Class<TT> depend) {
+    public <T> T getDependAccountResult(final Class<T> depend) {
         final DifferPressParser differPressParser = DifferPressParser.DIFFER_PRESS_PARSERS.get(loginUserToken.getAccount());
         final Object baseDes = differPressParser.dependencys.get(depend);
         if (null != baseDes) {
-            return (TT) baseDes;
+            return (T) baseDes;
         }
         return null;
     }
@@ -210,7 +210,7 @@ public abstract class BaseParser<Method extends HttpRequest, M extends BaseDes, 
         if (null == loginUserToken) {
             throw new CloudDiskException("至少给一个解析器初始化用户信息");
         }
-        final Method request = initRequest(parameter);
+        final M1 request = initRequest(parameter);
         final M m = execute(request);
         cookieStoreUT.setCookieStore(httpClientContext.getCookieStore());
         return m;
@@ -229,15 +229,15 @@ public abstract class BaseParser<Method extends HttpRequest, M extends BaseDes, 
     }
 
     @SuppressWarnings("unchecked")
-    public Method initRequest(final Parameter parameter) {
-        Method method = null;
+    public M1 initRequest(final Parameter parameter) {
+        M1 method = null;
         uriPath = getUriPath();
         if (StringUtils.isNotBlank(uriPath)) {
             final String host = getRedSchmemHost();
             if (requestMethod instanceof HttpGet) {
-                method = (Method) new HttpGet(host + uriPath);
+                method = (M1) new HttpGet(host + uriPath);
             }else{
-                method = (Method) new HttpPost(host + uriPath);
+                method = (M1) new HttpPost(host + uriPath);
             }
             return method;
         }else{
@@ -262,7 +262,7 @@ public abstract class BaseParser<Method extends HttpRequest, M extends BaseDes, 
         return RequestConfig.custom().setCookieSpec(cookieSpecs).build();
     }
 
-    public M execute(final Method request) {
+    public M execute(final M1 request) {
         if (hasException()) {
             return execClouddiskException();
         }
@@ -281,7 +281,7 @@ public abstract class BaseParser<Method extends HttpRequest, M extends BaseDes, 
         return null;
     }
 
-    public void executeException(final Exception e,final Method request){
+    public void executeException(final Exception e,final M1 request){
         if(e instanceof SocketTimeoutException){
             final String errMsg = request.getRequestLine()+" Socket连接超时";
             this.cloudDiskException = new CloudDiskException(errMsg);

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/BaseRequestInterceptor.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/BaseRequestInterceptor.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-public class BaseRequestInterceptor<Const extends BaseConst,Parser extends BaseParser> implements HttpRequestInterceptor {
+public class BaseRequestInterceptor<C  extends BaseConst,Parser extends BaseParser> implements HttpRequestInterceptor {
 	
 	private static final Logger LOGGER = LoggerFactory.getLogger(BaseRequestInterceptor.class);
 
@@ -25,12 +25,12 @@ public class BaseRequestInterceptor<Const extends BaseConst,Parser extends BaseP
 	}
 	
 	public void requestInit(final HttpRequest request, final HttpContext context)throws HttpException, IOException {
-		request.setHeader(Const.ACCEPT_KEY, Const.ACCEPT_VAL);
-		request.setHeader(Const.ACCEPT_ENCODING_KEY, Const.ACCEPT_ENCODING_VAL);
-		request.setHeader(Const.ACCEPT_LANGUAGE_KEY, Const.ACCEPT_LANGUAGE_VAL);
-		request.setHeader(Const.CONNECTION_KEY, Const.CONNECTION_VAL);
-		request.setHeader(Const.CONTENT_TYPE_KEY, Const.CONTENT_TYPE_VAL);
-		request.setHeader(Const.USER_AGENT_KEY, Const.USER_AGENT_VAL);
+		request.setHeader(C.ACCEPT_KEY, C.ACCEPT_VAL);
+		request.setHeader(C.ACCEPT_ENCODING_KEY, C.ACCEPT_ENCODING_VAL);
+		request.setHeader(C.ACCEPT_LANGUAGE_KEY, C.ACCEPT_LANGUAGE_VAL);
+		request.setHeader(C.CONNECTION_KEY, C.CONNECTION_VAL);
+		request.setHeader(C.CONTENT_TYPE_KEY, C.CONTENT_TYPE_VAL);
+		request.setHeader(C.USER_AGENT_KEY, C.USER_AGENT_VAL);
 	}
 	
 	public void process(final HttpRequest request, final HttpContext context,boolean useHost) throws HttpException, IOException {
@@ -38,13 +38,13 @@ public class BaseRequestInterceptor<Const extends BaseConst,Parser extends BaseP
 		final String hostName = parser.getRedHost();
 		final String host = parser.getRedSchmemHost();
 		if(StringUtils.isNotBlank(hostName)){
-			request.setHeader(Const.HOST_KEY,hostName);
+			request.setHeader(C.HOST_KEY,hostName);
 		}else{
-			request.setHeader(Const.HOST_KEY, Const.HOST_VAL);
+			request.setHeader(C.HOST_KEY, C.HOST_VAL);
 		}
 		if(StringUtils.isNotBlank(host)){
-			request.setHeader(Const.REFERER_KEY, host+"/my/index");
-			request.setHeader(Const.ORIGIN_KEY, host);
+			request.setHeader(C.REFERER_KEY, host+"/my/index");
+			request.setHeader(C.ORIGIN_KEY, host);
 		}else{
 			LOGGER.error("Referer 与 Origin 不能为空");
 		}


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S00119 - “ Package names should comply with a naming convention”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S00119
 Please let me know if you have any questions.
Fevzi Ozgul
