### PR TITLE
Fixing squid: S1170 Public constants and fields initialized at declaration should be "static final" rather than merely "final"

### DIFF
--- a/src/main/java/com/dounine/clouddisk360/parser/CaptchaParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/CaptchaParser.java
@@ -34,9 +34,9 @@ public class CaptchaParser extends
 			uri.setParameter(CONST.CHARSET_KEY, CONST.CHARSET_VAL);
 			uri.setParameter(CONST.REQUESTSCEMA_KEY, CONST.REQUESTSCEMA_VAL);
 			uri.setParameter(CONST.O_KEY, CONST.O_VAL);
-			uri.setParameter(CONST.M_KEY, CONST.M_VAL);
-			uri.setParameter(CONST.ACCOUNT_NAME, loginUserToken.getAccount());
-			uri.setParameter(CONST.CAPTCHAAPP_KEY, CONST.CAPTCHAAPP_VAL);
+			uri.setParameter(CaptchaConst.M_KEY, CaptchaConst.M_VAL);
+			uri.setParameter(CaptchaConst.ACCOUNT_NAME, loginUserToken.getAccount());
+			uri.setParameter(CaptchaConst.CAPTCHAAPP_KEY, CaptchaConst.CAPTCHAAPP_VAL);
 			request = new HttpGet(uri.build());
 		} catch (URISyntaxException e) {
 			LOGGER.error("Error",e);

--- a/src/main/java/com/dounine/clouddisk360/parser/DifferPressParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/DifferPressParser.java
@@ -55,10 +55,10 @@ public class DifferPressParser extends
 	public HttpGet initRequest(final DifferPressParameter parameter) {
 		HttpGet request = null;
 		try {
-			final URIBuilder uri = new URIBuilder(CONST.URI_PATH);
-			uri.setParameter(CONST.ST_KEY, TimeUtil.getTimeLenth(10));
-			uri.setParameter(CONST.SID_KEY, StringUtils.EMPTY);
-			uri.setParameter(CONST.KEEPALIVE_KEY, CONST.KEEPALIVE_VAL);
+			final URIBuilder uri = new URIBuilder(DifferPressConst.URI_PATH);
+			uri.setParameter(DifferPressConst.ST_KEY, TimeUtil.getTimeLenth(10));
+			uri.setParameter(DifferPressConst.SID_KEY, StringUtils.EMPTY);
+			uri.setParameter(DifferPressConst.KEEPALIVE_KEY, DifferPressConst.KEEPALIVE_VAL);
 			request = new HttpGet(uri.build());
 		} catch (URISyntaxException e) {
 			LOGGER.error("Error",e);

--- a/src/main/java/com/dounine/clouddisk360/parser/FileCreateParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/FileCreateParser.java
@@ -30,7 +30,7 @@ public class FileCreateParser extends
 	public HttpPost initRequest(final FileCreateParameter parameter) {
 		final HttpPost request = new HttpPost(getRequestUri());
 		final List<NameValuePair> data = new ArrayList<>(2);
-		data.add(new BasicNameValuePair(CONST.PATH_NAME, parameter.getPath()));
+		data.add(new BasicNameValuePair(FileCreateConst.PATH_NAME, parameter.getPath()));
 		data.add(new BasicNameValuePair(CONST.AJAX_KEY, CONST.AJAX_VAL));
 		request.setEntity(new UrlEncodedFormEntity(data, Consts.UTF_8));
 		return request;

--- a/src/main/java/com/dounine/clouddisk360/parser/LoginParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/LoginParser.java
@@ -42,35 +42,35 @@ public class LoginParser extends
 
 	@Override
 	public HttpPost initRequest(final LoginParameter parameter) {
-		final HttpPost request = new HttpPost(CONST.URI_PATH);
+		final HttpPost request = new HttpPost(LoginConst.URI_PATH);
 		final List<NameValuePair> data = new ArrayList<>();
 		data.add(new BasicNameValuePair(CONST.SRC_KEY, CONST.SRC_VAL));
 		data.add(new BasicNameValuePair(CONST.FROM_KEY, CONST.FROM_VAL));
 		data.add(new BasicNameValuePair(CONST.CHARSET_KEY, CONST.SRC_VAL));
-		data.add(new BasicNameValuePair(CONST.REQUESTSCEMA_KEY, CONST.REQUESTSCEMA_VAL));
+		data.add(new BasicNameValuePair(LoginConst.REQUESTSCEMA_KEY, LoginConst.REQUESTSCEMA_VAL));
 		data.add(new BasicNameValuePair(CONST.O_KEY, CONST.O_VAL));
-		data.add(new BasicNameValuePair(CONST.M_KEY, CONST.M_VAL));
-		data.add(new BasicNameValuePair(CONST.LM_KEY, CONST.LM_VAL));
-		data.add(new BasicNameValuePair(CONST.CAPTFLAG_KEY, CONST.CAPTFLAG_VAL));
-		data.add(new BasicNameValuePair(CONST.RTYPE_KEY, CONST.RTYPE_VAL));
-		data.add(new BasicNameValuePair(CONST.VALIDATELM_KEY, CONST.VALIDATELM_VAL));
-		data.add(new BasicNameValuePair(CONST.ISKEEPALIVE_KEY, CONST.ISKEEPALIVE_VAL));
-		data.add(new BasicNameValuePair(CONST.CAPTCHAAPP_KEY, CONST.CAPTCHAAPP_VAL));
-		data.add(new BasicNameValuePair(CONST.USERNAME_NAME, loginUserToken.getAccount()));
-		data.add(new BasicNameValuePair(CONST.TYPE_KEY, LoginConst.TYPE_VAL));
-		data.add(new BasicNameValuePair(CONST.ACCOUNT_NAME, loginUserToken.getAccount()));
+		data.add(new BasicNameValuePair(LoginConst.M_KEY, LoginConst.M_VAL));
+		data.add(new BasicNameValuePair(LoginConst.LM_KEY, LoginConst.LM_VAL));
+		data.add(new BasicNameValuePair(LoginConst.CAPTFLAG_KEY, LoginConst.CAPTFLAG_VAL));
+		data.add(new BasicNameValuePair(LoginConst.RTYPE_KEY, LoginConst.RTYPE_VAL));
+		data.add(new BasicNameValuePair(LoginConst.VALIDATELM_KEY, LoginConst.VALIDATELM_VAL));
+		data.add(new BasicNameValuePair(LoginConst.ISKEEPALIVE_KEY, LoginConst.ISKEEPALIVE_VAL));
+		data.add(new BasicNameValuePair(LoginConst.CAPTCHAAPP_KEY, LoginConst.CAPTCHAAPP_VAL));
+		data.add(new BasicNameValuePair(LoginConst.USERNAME_NAME, loginUserToken.getAccount()));
+		data.add(new BasicNameValuePair(LoginConst.TYPE_KEY, LoginConst.TYPE_VAL));
+		data.add(new BasicNameValuePair(LoginConst.ACCOUNT_NAME, loginUserToken.getAccount()));
 		if (loginUserToken.isMd5()) {
-			data.add(new BasicNameValuePair(CONST.PASSWORD_NAME, loginUserToken.getPassword()));
+			data.add(new BasicNameValuePair(LoginConst.PASSWORD_NAME, loginUserToken.getPassword()));
 		} else {
-			data.add(new BasicNameValuePair(CONST.PASSWORD_NAME, MD5Util.MD5(loginUserToken.getPassword())));
+			data.add(new BasicNameValuePair(LoginConst.PASSWORD_NAME, MD5Util.MD5(loginUserToken.getPassword())));
 		}
 		if (StringUtils.isNotBlank(parameter.getCaptchaValue())) {
-			data.add(new BasicNameValuePair(CONST.CAPTCHA_KEY, parameter.getCaptchaValue()));
+			data.add(new BasicNameValuePair(LoginConst.CAPTCHA_KEY, parameter.getCaptchaValue()));
 		} else {
-			data.add(new BasicNameValuePair(CONST.CAPTCHA_KEY, StringUtils.EMPTY));
+			data.add(new BasicNameValuePair(LoginConst.CAPTCHA_KEY, StringUtils.EMPTY));
 		}
 		if (StringUtils.isNotBlank(parameter.getToken())) {
-			data.add(new BasicNameValuePair(CONST.TOKEN_NAME, parameter.getToken()));
+			data.add(new BasicNameValuePair(LoginConst.TOKEN_NAME, parameter.getToken()));
 		} else {
 			throw new CloudDiskException("登录所需token令牌不能为空.");
 		}

--- a/src/main/java/com/dounine/clouddisk360/parser/UserCheckLoginParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/UserCheckLoginParser.java
@@ -1,6 +1,7 @@
 package com.dounine.clouddisk360.parser;
 
 import com.dounine.clouddisk360.annotation.Parse;
+import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 import com.dounine.clouddisk360.parser.deserializer.login.Login;
 import com.dounine.clouddisk360.parser.deserializer.login.LoginConst;
 import com.dounine.clouddisk360.parser.deserializer.login.LoginUserToken;
@@ -43,8 +44,8 @@ public class UserCheckLoginParser extends
 		}
 		final HttpPost request = new HttpPost(CONST.URI_PATH);
 		final List<NameValuePair> data = new ArrayList<>();
-		data.add(new BasicNameValuePair(CONST.QID_NAME, login.getQid()));
-		data.add(new BasicNameValuePair(CONST.METHOD_KEY, CONST.METHOD_VAL));
+		data.add(new BasicNameValuePair(UserCheckLoginConst.QID_NAME, login.getQid()));
+		data.add(new BasicNameValuePair(UserCheckLoginConst.METHOD_KEY, UserCheckLoginConst.METHOD_VAL));
 		data.add(new BasicNameValuePair(CONST.AJAX_KEY, CONST.AJAX_VAL));
 		data.add(new BasicNameValuePair("t", TimeUtil.getTimeLenth(13)));
 		request.setConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.NETSCAPE).build());
@@ -57,7 +58,7 @@ public class UserCheckLoginParser extends
 		httpClient = HttpClients.custom()
 				.setConnectionManager(PoolingHttpClientConnection.getInstalce())
 				.addInterceptorLast(requestInterceptor)
-				.setDefaultCookieStore(cookieStoreUT.readCookieStoreForDisk(CONST.BASE_COOKIES_VALUES))
+				.setDefaultCookieStore(cookieStoreUT.readCookieStoreForDisk(BaseConst.BASE_COOKIES_VALUES))
 				.build();
 		try {
 			return httpClient.execute(request, responseHandler, this.httpClientContext);

--- a/src/main/java/com/dounine/clouddisk360/parser/UserInfoParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/UserInfoParser.java
@@ -3,6 +3,7 @@ package com.dounine.clouddisk360.parser;
 import com.dounine.clouddisk360.annotation.DependResult;
 import com.dounine.clouddisk360.annotation.Dependency;
 import com.dounine.clouddisk360.annotation.Parse;
+import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 import com.dounine.clouddisk360.parser.deserializer.login.LoginUserToken;
 import com.dounine.clouddisk360.parser.deserializer.user.info.*;
 import com.dounine.clouddisk360.pool.PoolingHttpClientConnection;
@@ -43,11 +44,11 @@ public class UserInfoParser extends
 			uriBuilder.addParameter(CONST.SRC_KEY, CONST.SRC_VAL);
 			uriBuilder.addParameter(CONST.FROM_KEY, CONST.FROM_VAL);
 			uriBuilder.addParameter(CONST.CHARSET_KEY, CONST.CHARSET_VAL);
-			uriBuilder.addParameter(CONST.METHOD_KEY, CONST.METHOD_VAL);
+			uriBuilder.addParameter(UserInfoConst.METHOD_KEY, UserInfoConst.METHOD_VAL);
 			uriBuilder.addParameter(CONST.REQUESTSCEMA_KEY, CONST.REQUESTSCEMA_VAL);
 			uriBuilder.addParameter(CONST.O_KEY, CONST.O_VAL);
-			uriBuilder.addParameter(CONST.SHOW_NAME_FLAG_NAME, CONST.SHOW_NAME_FLAG_VALUE);
-			uriBuilder.addParameter(CONST.HEAD_TYPE_NAME, CONST.HEAD_TYPE_VAL);
+			uriBuilder.addParameter(UserInfoConst.SHOW_NAME_FLAG_NAME, UserInfoConst.SHOW_NAME_FLAG_VALUE);
+			uriBuilder.addParameter(UserInfoConst.HEAD_TYPE_NAME, UserInfoConst.HEAD_TYPE_VAL);
 			uriBuilder.addParameter("-", TimeUtil.getTimeLenth(13));
 			final HttpGet request = new HttpGet(uriBuilder.build());
 			request.setConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.NETSCAPE).build());
@@ -63,7 +64,7 @@ public class UserInfoParser extends
 		httpClient = HttpClients.custom()
 				.setConnectionManager(PoolingHttpClientConnection.getInstalce())
 				.addInterceptorLast(requestInterceptor)
-				.setDefaultCookieStore(cookieStoreUT.readCookieStoreForDisk(CONST.BASE_COOKIES_VALUES))
+				.setDefaultCookieStore(cookieStoreUT.readCookieStoreForDisk(BaseConst.BASE_COOKIES_VALUES))
 				.build();
 		try {
 			return httpClient.execute(request, responseHandler, this.httpClientContext);

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/captcha/CaptchaConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/captcha/CaptchaConst.java
@@ -6,12 +6,12 @@ public final class CaptchaConst extends BaseConst {
 
 	public final String URI_PATH = "http://login.360.cn/";
 	
-	public final String M_KEY = "m";
-	public final String M_VAL = "checkNeedCaptcha";
+	public static final String M_KEY = "m";
+	public static final String M_VAL = "checkNeedCaptcha";
 
-	public final String CAPTCHAAPP_KEY = "captchaApp";
-	public final String CAPTCHAAPP_VAL = "i360";
+	public static final String CAPTCHAAPP_KEY = "captchaApp";
+	public static final String CAPTCHAAPP_VAL = "i360";
 
-	public final String ACCOUNT_NAME = "account";
+	public static final String ACCOUNT_NAME = "account";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/differpre/DifferPressConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/differpre/DifferPressConst.java
@@ -4,15 +4,15 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class DifferPressConst extends BaseConst {
 
-	public final String URI_PATH = "http://yunpan.360.cn/user/login";
+	public static final String URI_PATH = "http://yunpan.360.cn/user/login";
 
-	public final String ST_KEY = "st";
+	public static final String ST_KEY = "st";
 	public static final String ST_VAL = "1457085516";
 
-	public final String SID_KEY = "sid";
+	public static final String SID_KEY = "sid";
 
-	public final String KEEPALIVE_KEY = "keepalive";
-	public final String KEEPALIVE_VAL = "1";
+	public static final String KEEPALIVE_KEY = "keepalive";
+	public static final String KEEPALIVE_VAL = "1";
 
 	public static final String HOST_VAL = "yunpan.360.cn";
 

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/create/FileCreateConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/create/FileCreateConst.java
@@ -4,7 +4,7 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileCreateConst extends BaseConst {
 
-	public final String URI_PATH = "/file/mkdir";
+	public static final String URI_PATH = "/file/mkdir";
 
 	@Override
 	public String getUriPath() {
@@ -19,6 +19,6 @@ public final class FileCreateConst extends BaseConst {
 
 	public static final String USERNAME_NAME = "userName";
 
-	public final String PATH_NAME = "path";
+	public static final String PATH_NAME = "path";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/login/LoginConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/login/LoginConst.java
@@ -5,51 +5,51 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public class LoginConst extends BaseConst {
 
 	public static final String USER_INFO_PATH_NAME = "user/userInfo.txt";
-	public final String URI_PATH = "https://login.360.cn/";
+	public static final String URI_PATH = "https://login.360.cn/";
 
 	public static final String LOGIN_URL = "https://login.360.cn/";
 	
 	public static final String QUCRYPTCODE_NAME = "quCryptCode";
 
-	public final String REQUESTSCEMA_KEY = "requestScema";
-	public final String REQUESTSCEMA_VAL = "https";
+	public static final String REQUESTSCEMA_KEY = "requestScema";
+	public static final String REQUESTSCEMA_VAL = "https";
 
-	public final String LM_KEY = "lm";
-	public final String LM_VAL = "0";
+	public static final String LM_KEY = "lm";
+	public static final String LM_VAL = "0";
 
-	public final String CAPTFLAG_KEY = "captFlag";
-	public final String CAPTFLAG_VAL = "1";
+	public static final String CAPTFLAG_KEY = "captFlag";
+	public static final String CAPTFLAG_VAL = "1";
 
-	public final String RTYPE_KEY = "rtype";
-	public final String RTYPE_VAL = "data";
+	public static final String RTYPE_KEY = "rtype";
+	public static final String RTYPE_VAL = "data";
 
-	public final String VALIDATELM_KEY = "validatelm";
-	public final String VALIDATELM_VAL = "0";
+	public static final String VALIDATELM_KEY = "validatelm";
+	public static final String VALIDATELM_VAL = "0";
 
 	/**
 	 * 记住我登录
 	 */
-	public final String ISKEEPALIVE_KEY = "isKeepAlive";
-	public final String ISKEEPALIVE_VAL = "1";
+	public static final String ISKEEPALIVE_KEY = "isKeepAlive";
+	public static final String ISKEEPALIVE_VAL = "1";
 
-	public final String CAPTCHAAPP_KEY = "captchaApp";
-	public final String CAPTCHAAPP_VAL = "i360";
+	public static final String CAPTCHAAPP_KEY = "captchaApp";
+	public static final String CAPTCHAAPP_VAL = "i360";
 
-	public final String TYPE_KEY = "type";
+	public static final String TYPE_KEY = "type";
 	public static final String TYPE_VAL = "normal";
 
-	public final String CAPTCHA_KEY = "captcha";
+	public static final String CAPTCHA_KEY = "captcha";
 
 	public static final String PROXY_KEY = "proxy";
 	public static final String PROXY_VAL = "http://yunpan.360.cn/psp_jump.html";
 
-	public final String M_KEY = "m";
-	public final String M_VAL = "login";
+	public static final String M_KEY = "m";
+	public static final String M_VAL = "login";
 
-	public final String TOKEN_NAME = "token";
-	public final String PASSWORD_NAME = "password";
-	public final String USERNAME_NAME = "userName";
-	public final String ACCOUNT_NAME = "account";
+	public static final String TOKEN_NAME = "token";
+	public static final String PASSWORD_NAME = "password";
+	public static final String USERNAME_NAME = "userName";
+	public static final String ACCOUNT_NAME = "account";
 
 	public static final String ORIGIN_KEY = "Origin";
 	public static final String ORIGIN_VAL = "http://yunpan.360.cn";

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/login/LoginUserToken.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/login/LoginUserToken.java
@@ -2,6 +2,7 @@ package com.dounine.clouddisk360.parser.deserializer.login;
 
 import java.io.Serializable;
 
+ 
 public class LoginUserToken implements Serializable{
 
 	private String account;

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/check/UserCheckLoginConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/check/UserCheckLoginConst.java
@@ -8,7 +8,7 @@ public final class UserCheckLoginConst extends BaseConst {
 
 	public static final String QID_NAME = "qid";
 
-	public static final String METHOD_KEY = "method";
+	public static final  String METHOD_KEY = "method";
 	public static final String METHOD_VAL = "check";
 
 }

--- a/src/test/java/com/dounine/clouddisk360/parse/FileListParserTest.java
+++ b/src/test/java/com/dounine/clouddisk360/parse/FileListParserTest.java
@@ -22,7 +22,7 @@ public class FileListParserTest extends TestCase {
 		fileListParameter.setOrder(Order.DESC);
 		fileListParameter.setPage(0);
 		fileListParameter.setPage_size(300);
-		fileListParameter.setPath(fileListParameter.ROOT_PATH);
+		fileListParameter.setPath(FileListParameter.ROOT_PATH);
 		final FileList fileList = fileListParser.parse(fileListParameter);
 		LOGGER.info(fileList.toString());
 	}


### PR DESCRIPTION
"This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1170 - “Public constants and fields initialized at declaration should be "static final" rather than merely "final"”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1170
 Please let me know if you have any questions.
Fevzi Ozgul
