### PR TITLE
Fixing squid: S1213 Members of an interface or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/com/dounine/clouddisk360/captthread/CaptchaThreadValidator.java
+++ b/src/main/java/com/dounine/clouddisk360/captthread/CaptchaThreadValidator.java
@@ -14,11 +14,13 @@ public class CaptchaThreadValidator implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(CaptchaThreadValidator.class);
     public static final int timeoutMin = 10 * 60;
     private static final String ACCOUNT_NOT_NULL = "account not empty";
-
+    private static Map<String, CaptchaValidator> captchaValidators = new ConcurrentHashMap(100);
+    private static final CaptchaThreadValidator captchaThreadValidator;
+    
     private CaptchaThreadValidator() {
     }
 
-    private static final CaptchaThreadValidator captchaThreadValidator;
+    
 
     static {
         captchaThreadValidator = new CaptchaThreadValidator();
@@ -29,7 +31,7 @@ public class CaptchaThreadValidator implements Runnable {
         return captchaThreadValidator;
     }
 
-    private static Map<String, CaptchaValidator> captchaValidators = new ConcurrentHashMap(100);
+    
 
     public static boolean isTimeout(final String account) {
         return isTimeout(account, false);

--- a/src/main/java/com/dounine/clouddisk360/parser/DifferPressParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/DifferPressParser.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class DifferPressParser extends
 		BaseParser<HttpGet, DifferPress, DifferPressConst, DifferPressParameter, DifferPressRequestInterceptor, DifferPressResponseHandle, DifferPressParser> {
 
+	public static final Logger LOGGER = LoggerFactory.getLogger(DifferPressParser.class);
 	public static final Map<String, DifferPressParser> DIFFER_PRESS_PARSERS = new ConcurrentHashMap();
 	private Captcha captcha;
 	private CaptchaParser captchaParser;
@@ -49,7 +50,7 @@ public class DifferPressParser extends
 		super(loginUser);
 	}
 
-	public static final Logger LOGGER = LoggerFactory.getLogger(DifferPressParser.class);
+	
 
 	@Override
 	public HttpGet initRequest(final DifferPressParameter parameter) {

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/create/FileCreateConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/create/FileCreateConst.java
@@ -5,12 +5,6 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileCreateConst extends BaseConst {
 
 	public final String URI_PATH = "/file/mkdir";
-
-	@Override
-	public String getUriPath() {
-		return URI_PATH;
-	}
-
 	public static final String REQUESTSCEMA_KEY = "requestScema";
 	public static final String REQUESTSCEMA_VAL = "https";
 
@@ -20,5 +14,10 @@ public final class FileCreateConst extends BaseConst {
 	public static final String USERNAME_NAME = "userName";
 
 	public final String PATH_NAME = "path";
+
+	@Override
+	public String getUriPath() {
+		return URI_PATH;
+	}
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/download/dladdress/FileDownloadAddressConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/download/dladdress/FileDownloadAddressConst.java
@@ -5,13 +5,12 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileDownloadAddressConst extends BaseConst {
 
 	public final String URI_PATH = "/file/download/";
-
+	public final String NID_NAME = "nid";
+	public final String FNAME_NAME = "fname";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
-
-	public final String NID_NAME = "nid";
-	public final String FNAME_NAME = "fname";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/exist/FileExistConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/exist/FileExistConst.java
@@ -5,13 +5,14 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileExistConst extends BaseConst {
 
 	public final String URI_PATH = "/file/detectFileExists";
-
+	public final String DIR_NAME = "dir";
+	public final String FNAME_NAME = "fname[]";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String DIR_NAME = "dir";
-	public final String FNAME_NAME = "fname[]";
+	
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/history/FileHistoryConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/history/FileHistoryConst.java
@@ -5,16 +5,17 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileHistoryConst extends BaseConst {
 
 	public final String URI_PATH = "/fHistory/getFileHistory/";
-
-	@Override
-	public String getUriPath() {
-		return URI_PATH;
-	}
-
 	public final String NID_NAME = "nid";
 	public final String HIS_NID_NAME = "his_nid";
 	public final String START_NAME = "start";
 	public final String NUM_NAME = "num";
 	public final String SOURCE_NAME = "source";
+	
+	@Override
+	public String getUriPath() {
+		return URI_PATH;
+	}
+
+	
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/history/restore/FileRestoreConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/history/restore/FileRestoreConst.java
@@ -5,14 +5,13 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileRestoreConst extends BaseConst {
 	
 	public final String URI_PATH = "/fHistory/restore";
-
+	public final String NID_NAME = "nid";
+	public final String ID_NAME = "id";
+	public final String SOURCE_NAME = "source";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
-
-	public final String NID_NAME = "nid";
-	public final String ID_NAME = "id";
-	public final String SOURCE_NAME = "source";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/list/FileListConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/list/FileListConst.java
@@ -5,12 +5,6 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileListConst extends BaseConst {
 
 	public final String URI_PATH = "/file/list";
-
-	@Override
-	public String getUriPath() {
-		return URI_PATH;
-	}
-
 	public static final String REQUESTSCEMA_KEY = "requestScema";
 	public static final String REQUESTSCEMA_VAL = "https";
 
@@ -25,5 +19,10 @@ public final class FileListConst extends BaseConst {
 	public static final String FIELD_VAL = "file_name";
 	public static final String PAGE_NAME = "page";
 	public final String PAGE_SIZE_NAME = "page_size";
+	
+	@Override
+	public String getUriPath() {
+		return URI_PATH;
+	}
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/move/FileMoveConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/move/FileMoveConst.java
@@ -5,14 +5,13 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileMoveConst extends BaseConst {
 
 	public final String URI_PATH = "/file/move/";
-
+	public final String PATH_NAME = "path[]";
+	public final String NEWPATH_NAME = "newpath";
+	public static final String NID_NAME = "nid";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
-
-	public final String PATH_NAME = "path[]";
-	public final String NEWPATH_NAME = "newpath";
-	public static final String NID_NAME = "nid";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/move/list/FileListAjaxConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/move/list/FileListAjaxConst.java
@@ -5,14 +5,13 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileListAjaxConst extends BaseConst {
 	
 	public final String URI_PATH = "/file/listAjax";
-
+	public final String PATH_NAME = "path";
+	public final String ID_NAME = "id";
+	public final String NID_NAME = "nid";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
-
-	public final String PATH_NAME = "path";
-	public final String ID_NAME = "id";
-	public final String NID_NAME = "nid";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/recycle/FileRecycleConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/recycle/FileRecycleConst.java
@@ -5,12 +5,11 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileRecycleConst extends BaseConst {
 
 	public final String URI_PATH = "/file/asyncRecycle/";
-
+	public final String PATH_NAME = "path[]";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
-
-	public final String PATH_NAME = "path[]";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/rename/FileRenameConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/rename/FileRenameConst.java
@@ -5,14 +5,13 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileRenameConst extends BaseConst {
 
 	public final String URI_PATH = "/file/rename";
-
+	public final String PATH_NAME = "path";
+	public final String NEWPATH_NAME = "newpath";
+	public final String NID_NAME = "nid";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
-
-	public final String PATH_NAME = "path";
-	public final String NEWPATH_NAME = "newpath";
-	public final String NID_NAME = "nid";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/search/FileSearchConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/search/FileSearchConst.java
@@ -5,14 +5,12 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileSearchConst extends BaseConst {
 
 	public final String URI_PATH = "/file/searchList";
-
+	public final String KEY_NAME = "key";
+	public final String ISFPATH_NAME = "is_fpath";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
-
-	public final String KEY_NAME = "key";
-	public final String ISFPATH_NAME = "is_fpath";
-
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/trends/FileTrendsListConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/trends/FileTrendsListConst.java
@@ -5,14 +5,13 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileTrendsListConst extends BaseConst {
 
 	public final String URI_PATH = "/trends/getTrendsList";
-
+	public static final String PATH_NAME = "path";
+	public static final String NEWPATH_NAME = "newpath";
+	public static final String NID_NAME = "nid";
+	
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
-
-	public static final String PATH_NAME = "path";
-	public static final String NEWPATH_NAME = "newpath";
-	public static final String NID_NAME = "nid";
 
 }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1213 - “Members of an interface or class should appear in a pre-defined order”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1213
 Please let me know if you have any questions.
Fevzi Ozgul
