### PR TITLE
Fixing squids:  squid:1160 Public methods should throw at most one checked exception

### DIFF
--- a/src/main/java/com/dounine/clouddisk360/parser/UserCheckLoginParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/UserCheckLoginParser.java
@@ -1,6 +1,7 @@
 package com.dounine.clouddisk360.parser;
 
 import com.dounine.clouddisk360.annotation.Parse;
+import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 import com.dounine.clouddisk360.parser.deserializer.login.Login;
 import com.dounine.clouddisk360.parser.deserializer.login.LoginConst;
 import com.dounine.clouddisk360.parser.deserializer.login.LoginUserToken;
@@ -43,8 +44,8 @@ public class UserCheckLoginParser extends
 		}
 		final HttpPost request = new HttpPost(CONST.URI_PATH);
 		final List<NameValuePair> data = new ArrayList<>();
-		data.add(new BasicNameValuePair(CONST.QID_NAME, login.getQid()));
-		data.add(new BasicNameValuePair(CONST.METHOD_KEY, CONST.METHOD_VAL));
+		data.add(new BasicNameValuePair(UserCheckLoginConst.QID_NAME, login.getQid()));
+		data.add(new BasicNameValuePair(UserCheckLoginConst.METHOD_KEY, UserCheckLoginConst.METHOD_VAL));
 		data.add(new BasicNameValuePair(CONST.AJAX_KEY, CONST.AJAX_VAL));
 		data.add(new BasicNameValuePair("t", TimeUtil.getTimeLenth(13)));
 		request.setConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.NETSCAPE).build());
@@ -57,7 +58,7 @@ public class UserCheckLoginParser extends
 		httpClient = HttpClients.custom()
 				.setConnectionManager(PoolingHttpClientConnection.getInstalce())
 				.addInterceptorLast(requestInterceptor)
-				.setDefaultCookieStore(cookieStoreUT.readCookieStoreForDisk(CONST.BASE_COOKIES_VALUES))
+				.setDefaultCookieStore(cookieStoreUT.readCookieStoreForDisk(BaseConst.BASE_COOKIES_VALUES))
 				.build();
 		try {
 			return httpClient.execute(request, responseHandler, this.httpClientContext);

--- a/src/main/java/com/dounine/clouddisk360/parser/UserInfoParser.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/UserInfoParser.java
@@ -3,6 +3,7 @@ package com.dounine.clouddisk360.parser;
 import com.dounine.clouddisk360.annotation.DependResult;
 import com.dounine.clouddisk360.annotation.Dependency;
 import com.dounine.clouddisk360.annotation.Parse;
+import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 import com.dounine.clouddisk360.parser.deserializer.login.LoginUserToken;
 import com.dounine.clouddisk360.parser.deserializer.user.info.*;
 import com.dounine.clouddisk360.pool.PoolingHttpClientConnection;
@@ -43,11 +44,11 @@ public class UserInfoParser extends
 			uriBuilder.addParameter(CONST.SRC_KEY, CONST.SRC_VAL);
 			uriBuilder.addParameter(CONST.FROM_KEY, CONST.FROM_VAL);
 			uriBuilder.addParameter(CONST.CHARSET_KEY, CONST.CHARSET_VAL);
-			uriBuilder.addParameter(CONST.METHOD_KEY, CONST.METHOD_VAL);
+			uriBuilder.addParameter(UserInfoConst.METHOD_KEY, UserInfoConst.METHOD_VAL);
 			uriBuilder.addParameter(CONST.REQUESTSCEMA_KEY, CONST.REQUESTSCEMA_VAL);
 			uriBuilder.addParameter(CONST.O_KEY, CONST.O_VAL);
-			uriBuilder.addParameter(CONST.SHOW_NAME_FLAG_NAME, CONST.SHOW_NAME_FLAG_VALUE);
-			uriBuilder.addParameter(CONST.HEAD_TYPE_NAME, CONST.HEAD_TYPE_VAL);
+			uriBuilder.addParameter(UserInfoConst.SHOW_NAME_FLAG_NAME, UserInfoConst.SHOW_NAME_FLAG_VALUE);
+			uriBuilder.addParameter(UserInfoConst.HEAD_TYPE_NAME, UserInfoConst.HEAD_TYPE_VAL);
 			uriBuilder.addParameter("-", TimeUtil.getTimeLenth(13));
 			final HttpGet request = new HttpGet(uriBuilder.build());
 			request.setConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.NETSCAPE).build());
@@ -63,7 +64,7 @@ public class UserInfoParser extends
 		httpClient = HttpClients.custom()
 				.setConnectionManager(PoolingHttpClientConnection.getInstalce())
 				.addInterceptorLast(requestInterceptor)
-				.setDefaultCookieStore(cookieStoreUT.readCookieStoreForDisk(CONST.BASE_COOKIES_VALUES))
+				.setDefaultCookieStore(cookieStoreUT.readCookieStoreForDisk(BaseConst.BASE_COOKIES_VALUES))
 				.build();
 		try {
 			return httpClient.execute(request, responseHandler, this.httpClientContext);

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/BaseRequestInterceptor.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/BaseRequestInterceptor.java
@@ -24,30 +24,44 @@ public class BaseRequestInterceptor<C  extends BaseConst,Parser extends BasePars
 		requestInit(request,context);
 	}
 	
-	public void requestInit(final HttpRequest request, final HttpContext context)throws HttpException, IOException {
-		request.setHeader(C.ACCEPT_KEY, C.ACCEPT_VAL);
-		request.setHeader(C.ACCEPT_ENCODING_KEY, C.ACCEPT_ENCODING_VAL);
-		request.setHeader(C.ACCEPT_LANGUAGE_KEY, C.ACCEPT_LANGUAGE_VAL);
-		request.setHeader(C.CONNECTION_KEY, C.CONNECTION_VAL);
-		request.setHeader(C.CONTENT_TYPE_KEY, C.CONTENT_TYPE_VAL);
-		request.setHeader(C.USER_AGENT_KEY, C.USER_AGENT_VAL);
+	public void requestInit(final HttpRequest request, final HttpContext context) throws HttpException, IOException {
+		try{
+			request.setHeader(C.ACCEPT_KEY, C.ACCEPT_VAL);
+			request.setHeader(C.ACCEPT_ENCODING_KEY, C.ACCEPT_ENCODING_VAL);
+			request.setHeader(C.ACCEPT_LANGUAGE_KEY, C.ACCEPT_LANGUAGE_VAL);
+			request.setHeader(C.CONNECTION_KEY, C.CONNECTION_VAL);
+			request.setHeader(C.CONTENT_TYPE_KEY, C.CONTENT_TYPE_VAL);
+			request.setHeader(C.USER_AGENT_KEY, C.USER_AGENT_VAL);
+		}
+		catch (Exception ex) { 
+			LOGGER.error("RequestContext",ex);
+		    throw ex;
+		}
+		
 	}
 	
 	public void process(final HttpRequest request, final HttpContext context,boolean useHost) throws HttpException, IOException {
-		requestInit(request,context);
-		final String hostName = parser.getRedHost();
-		final String host = parser.getRedSchmemHost();
-		if(StringUtils.isNotBlank(hostName)){
-			request.setHeader(C.HOST_KEY,hostName);
-		}else{
-			request.setHeader(C.HOST_KEY, C.HOST_VAL);
+		try{
+			requestInit(request,context);
+			final String hostName = parser.getRedHost();
+			final String host = parser.getRedSchmemHost();
+			if(StringUtils.isNotBlank(hostName)){
+				request.setHeader(C.HOST_KEY,hostName);
+			}else{
+				request.setHeader(C.HOST_KEY, C.HOST_VAL);
+			}
+			if(StringUtils.isNotBlank(host)){
+				request.setHeader(C.REFERER_KEY, host+"/my/index");
+				request.setHeader(C.ORIGIN_KEY, host);
+			}else{
+				LOGGER.error("Referer 与 Origin 不能为空");
+			}
 		}
-		if(StringUtils.isNotBlank(host)){
-			request.setHeader(C.REFERER_KEY, host+"/my/index");
-			request.setHeader(C.ORIGIN_KEY, host);
-		}else{
-			LOGGER.error("Referer 与 Origin 不能为空");
+		catch(Exception ex){
+			LOGGER.error("ProcessContext",ex);
+		    throw ex;
 		}
+		
 	}
 
 }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1160 - “Public methods should throw at most one checked exception”. 
squid: S1170 -"public final fields should not be merely final."
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1160
https: https://dev.eclipse.org/sonar/rules/show/squid:S1170
 Please let me know if you have any questions.
Fevzi Ozgul
