### PR TITLE
Fixing squid: S1213 The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/rename/FileRenameConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/rename/FileRenameConst.java
@@ -5,14 +5,15 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileRenameConst extends BaseConst {
 
 	public final String URI_PATH = "/file/rename";
+	public final String PATH_NAME = "path";
+	public final String NEWPATH_NAME = "newpath";
+	public final String NID_NAME = "nid";
 
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String PATH_NAME = "path";
-	public final String NEWPATH_NAME = "newpath";
-	public final String NID_NAME = "nid";
+
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/search/FileSearchConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/search/FileSearchConst.java
@@ -5,14 +5,15 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 public final class FileSearchConst extends BaseConst {
 
 	public final String URI_PATH = "/file/searchList";
+	public final String KEY_NAME = "key";
+	public final String ISFPATH_NAME = "is_fpath";
 
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String KEY_NAME = "key";
-	public final String ISFPATH_NAME = "is_fpath";
+
 
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/trends/FileTrendsListConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/trends/FileTrendsListConst.java
@@ -4,15 +4,16 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileTrendsListConst extends BaseConst {
 
-	public final String URI_PATH = "/trends/getTrendsList";
+	public static final String PATH_NAME = "path";
+	public static final String NEWPATH_NAME = "newpath";
+	public static final String NID_NAME = "nid";
+    public final String URI_PATH = "/trends/getTrendsList";
 
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public static final String PATH_NAME = "path";
-	public static final String NEWPATH_NAME = "newpath";
-	public static final String NID_NAME = "nid";
+
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/upload/addfile/FileAddFileConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/file/upload/addfile/FileAddFileConst.java
@@ -4,14 +4,15 @@ import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class FileAddFileConst extends BaseConst {
 
-	public final String URI_PATH = "/upload/addfile";
+    public static final String NID_NAME = "nid";
+    public final String URI_PATH = "/upload/addfile";
+	public final String TK_NAME = "tk";
 
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String TK_NAME = "tk";
-	public static final String NID_NAME = "nid";
+
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/signin/UserSigninConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/signin/UserSigninConst.java
@@ -3,19 +3,19 @@ package com.dounine.clouddisk360.parser.deserializer.user.signin;
 import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class UserSigninConst extends BaseConst {
-	
+
+	public static final String METHOD_VAL = "signin";
+	public static final String T_NAME = "t";
 	public final String URI_PATH = "/user/signin/";
+    public final String QID_NAME = "qid";
+    public final String METHOD_KEY = "method";
+    public final String AJAX_KEY = "1";
 
 	@Override
 	public String getUriPath() {
 		return URI_PATH;
 	}
 
-	public final String QID_NAME = "qid";
-	public final String METHOD_KEY = "method";
-	public static final String METHOD_VAL = "signin";
 
-	public static final String T_NAME = "t";
-	public final String AJAX_KEY = "1";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/size/UserSizeConst.java
+++ b/src/main/java/com/dounine/clouddisk360/parser/deserializer/user/size/UserSizeConst.java
@@ -3,7 +3,10 @@ package com.dounine.clouddisk360.parser.deserializer.user.size;
 import com.dounine.clouddisk360.parser.deserializer.BaseConst;
 
 public final class UserSizeConst extends BaseConst {
-	
+
+	public static final String QID_NAME = "qid";
+	public static final String METHOD_KEY = "method";
+	public static final String METHOD_VAL = "signin";
 	public final String URI_PATH = "/user/getsize/?ajax=1";
 
 	@Override
@@ -11,9 +14,6 @@ public final class UserSizeConst extends BaseConst {
 		return URI_PATH;
 	}
 
-	public static final String QID_NAME = "qid";
 
-	public static final String METHOD_KEY = "method";
-	public static final String METHOD_VAL = "signin";
 
 }

--- a/src/main/java/com/dounine/clouddisk360/store/DomainStoreUT.java
+++ b/src/main/java/com/dounine/clouddisk360/store/DomainStoreUT.java
@@ -6,15 +6,15 @@ import com.dounine.clouddisk360.exception.CloudDiskException;
 
 public class DomainStoreUT {
 
-	private DomainStoreUT() {}
-
 	private static final DomainStoreUT domainStoreUT = new DomainStoreUT();
 	private String domain;
+
+	private DomainStoreUT() {}
 
 	public static DomainStoreUT getInstance() {
 		return domainStoreUT;
 	}
-	
+
 	public static String parserDomain(String uri){
 		uri = uri.substring(uri.indexOf("//")+2,uri.indexOf('.'));
 		return uri;


### PR DESCRIPTION
"This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1213 - “ The members of an interface declaration or class should appear in a pre-defined order”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1213
 Please let me know if you have any questions.
Fevzi Ozgul
